### PR TITLE
Fixing Organization Header

### DIFF
--- a/OpenAI.SDK/Managers/OpenAIService.cs
+++ b/OpenAI.SDK/Managers/OpenAIService.cs
@@ -25,7 +25,10 @@ namespace OpenAI.GPT3.Managers
             var authKey = settings.Value.ApiKey;
             _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {authKey}");
             var organization = settings.Value.Organization;
-            _httpClient.DefaultRequestHeaders.Add("OpenAI-Organization", $"{organization}");
+            if (!string.IsNullOrEmpty(organization))
+            {
+                _httpClient.DefaultRequestHeaders.Add("OpenAI-Organization", $"{organization}");
+            }
 
             _endpointProvider = new OpenAiEndpointProvider(settings.Value.ApiVersion);
             _engineId = OpenAiOptions.DefaultEngineId;

--- a/OpenAI.SDK/Models/Engines.cs
+++ b/OpenAI.SDK/Models/Engines.cs
@@ -24,6 +24,8 @@
         public static string DavinciCodex => "davinci-codex";
         public static string DavinciInstructBeta => "davinci-instruct-beta";
         public static string DavinciInstructBetaV3 => "davinci-instruct-beta-v3";
+        public static string DavinciTextV1 => "text-davinci-001";
+        public static string DavinciTextV2 => "text-davinci-002";
 
         public static string EnumToString(this Engine engine)
         {
@@ -37,7 +39,8 @@
                 Engine.Davinci => "davinci",
                 Engine.DavinciCodex => "davinci-codex",
                 Engine.DavinciInstructBeta => "davinci-instruct-beta",
-                Engine.DavinciInstructBetaV3 => "davinci-instruct-beta-v3",
+                Engine.DavinciTextV1 => "text-davinci-001",
+                Engine.DavinciTextV2 => "text-davinci-002",
 
                 _ => throw new ArgumentOutOfRangeException(nameof(engine), engine, null)
             };

--- a/OpenAI.SDK/Models/Engines.cs
+++ b/OpenAI.SDK/Models/Engines.cs
@@ -12,7 +12,9 @@
             Davinci,
             DavinciCodex,
             DavinciInstructBeta,
-            DavinciInstructBetaV3
+            DavinciInstructBetaV3,
+            DavinciTextV1,
+            DavinciTextV2
         }
 
         public static string Ada => "ada";


### PR DESCRIPTION
I have an issue because im testing with a personal api account, and therefore i have no Organization Id, but the http request still append an empty `OpenAI-Organization` to the header, which the Open AI API don't allow. So i have fixed this.
Plus i have added the two new engines id.