### PR TITLE
build: generate doc file for nuget package

### DIFF
--- a/OpenAI.SDK/OpenAI.GPT3.csproj
+++ b/OpenAI.SDK/OpenAI.GPT3.csproj
@@ -18,7 +18,7 @@
 		<PackageTags>openAI,gpt-3,ai,betalgo,NLP</PackageTags>
 		<PackageId>Betalgo.$(AssemblyName)</PackageId>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
-		<GenerateDocumentationFile>False</GenerateDocumentationFile>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\Readme.md">


### PR DESCRIPTION
Not sure if this is disabled for a reason currently.