### PR TITLE
fix: json property name of user property

### DIFF
--- a/OpenAI.SDK/ObjectModels/RequestModels/CompletionCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/CompletionCreateRequest.cs
@@ -123,6 +123,7 @@ namespace OpenAI.GPT3.ObjectModels.RequestModels
         /// <summary>
         ///     A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
         /// </summary>
+        [JsonPropertyName("user")]
         public string User { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# Issue

When specifying the `User` field of `CompletionCreateRequest`, OpenAI responds with the error:

```
Unrecognized request argument supplied: User
```

# Fix

OpenAI treats JSON property names as case sensitive. This PR correctly sets the property name as `"user"` instead of `"User"`.