### PR TITLE
Fix LogProbs serialization bug

### DIFF
--- a/OpenAI.Playground/TestHelpers/CompletionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/CompletionTestHelper.cs
@@ -17,7 +17,8 @@ namespace OpenAI.Playground.TestHelpers
                 {
                     Prompt = "Once upon a time",
                     //    PromptAsList = new []{"Once upon a time"},
-                    MaxTokens = 5
+                    MaxTokens = 5,
+                    LogProbs = 1,
                 }, Models.Davinci);
 
                 if (completionResult.Successful)

--- a/OpenAI.SDK/ObjectModels/RequestModels/CompletionCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/CompletionCreateRequest.cs
@@ -10,7 +10,7 @@ namespace OpenAI.GPT3.ObjectModels.RequestModels
     /// <summary>
     ///     Create Completion Request Model
     /// </summary>
-    public record CompletionCreateRequest : IModelValidate, IOpenAiModels.ITemperature, IOpenAiModels.IModel, IOpenAiModels.ILogProbs, IOpenAiModels.IUser
+    public record CompletionCreateRequest : IModelValidate, IOpenAiModels.ITemperature, IOpenAiModels.IModel, IOpenAiModels.ILogProbsRequest, IOpenAiModels.IUser
     {
         /// <summary>
         ///     The prompt(s) to generate completions for, encoded as a string, a list of strings, or a list of token lists.

--- a/OpenAI.SDK/ObjectModels/SharedModels/ChoiceResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/ChoiceResponse.cs
@@ -2,7 +2,7 @@
 
 namespace OpenAI.GPT3.ObjectModels.SharedModels;
 
-public record ChoiceResponse : IOpenAiModels.ILogProbs
+public record ChoiceResponse : IOpenAiModels.ILogProbsResponse
 {
     [JsonPropertyName("text")] public string Text { get; set; }
 
@@ -10,5 +10,5 @@ public record ChoiceResponse : IOpenAiModels.ILogProbs
 
     [JsonPropertyName("finish_reason")] public string FinishReason { get; set; }
 
-    [JsonPropertyName("logprobs")] public int? LogProbs { get; set; }
+    [JsonPropertyName("logprobs")] public LogProbsResponse LogProbs { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
@@ -12,9 +12,14 @@
             string Model { get; set; }
         }
 
-        public interface ILogProbs
+        public interface ILogProbsRequest
         {
             int? LogProbs { get; set; }
+        }
+
+        public interface ILogProbsResponse
+        {
+            LogProbsResponse LogProbs { get; set; }
         }
 
         public interface ITemperature

--- a/OpenAI.SDK/ObjectModels/SharedModels/LogProbsResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/LogProbsResponse.cs
@@ -4,11 +4,13 @@ namespace OpenAI.GPT3.ObjectModels.SharedModels;
 
 public record LogProbsResponse
 {
-    [JsonPropertyName("tokens")] public string[] Tokens { get; set; }
+    [JsonPropertyName("tokens")] public List<string> Tokens { get; set; }
 
-    [JsonPropertyName("token_logprobs")] public double[] TokenLogProbs { get; set; }
+    [JsonPropertyName("token_logprobs")] public List<double> TokenLogProbs { get; set; }
 
-    [JsonPropertyName("top_logprobs")] public Dictionary<string,double>[] TopLogProbs { get; set; }
+    [JsonPropertyName("top_logprobs")] public List<Dictionary<string, double>> TopLogProbsRaw { get; set; }
 
-    [JsonPropertyName("text_offset")] public int[] TextOffset { get; set; }
+    public Dictionary<string, double> TopLogProbs => TopLogProbsRaw.SelectMany(r => r).ToDictionary(k => k.Key, k => k.Value);
+
+    [JsonPropertyName("text_offset")] public List<int> TextOffset { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/SharedModels/LogProbsResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/LogProbsResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace OpenAI.GPT3.ObjectModels.SharedModels;
+
+public record LogProbsResponse
+{
+    [JsonPropertyName("tokens")] public string[] Tokens { get; set; }
+
+    [JsonPropertyName("token_logprobs")] public double[] TokenLogProbs { get; set; }
+
+    [JsonPropertyName("top_logprobs")] public Dictionary<string,double>[] TopLogProbs { get; set; }
+
+    [JsonPropertyName("text_offset")] public int[] TextOffset { get; set; }
+}


### PR DESCRIPTION
Fix the problem connected with LogProbs serialization. 
This problem occurs because the type of LogProbs in ChoiseResponse was int?, but the actual type of the return value was different. Add the LogProbsResponse class to deserialize it properly. 
This problem was described in issue #54 (Including logprobs in request causes an error)
