### PR TITLE
Reduce code duplication by using one constructor

### DIFF
--- a/OpenAI.SDK/Managers/OpenAIService.cs
+++ b/OpenAI.SDK/Managers/OpenAIService.cs
@@ -13,22 +13,7 @@ namespace OpenAI.GPT3.Managers
 
         [ActivatorUtilitiesConstructor]
         public OpenAIService(HttpClient httpClient, IOptions<OpenAiOptions> settings)
-        {
-            settings.Value.Validate();
-
-            _httpClient = httpClient;
-            _httpClient.BaseAddress = new Uri(settings.Value.BaseDomain);
-            var authKey = settings.Value.ApiKey;
-            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {authKey}");
-            var organization = settings.Value.Organization;
-            if (!string.IsNullOrEmpty(organization))
-            {
-                _httpClient.DefaultRequestHeaders.Add("OpenAI-Organization", $"{organization}");
-            }
-
-            _endpointProvider = new OpenAiEndpointProvider(settings.Value.ApiVersion);
-            _engineId = OpenAiOptions.DefaultEngineId;
-        }
+        : this(settings.Value, httpClient) { }
 
         public OpenAIService(OpenAiOptions settings, HttpClient? httpClient = null)
         {


### PR DESCRIPTION
I've noticed that is is possible to reduce code duplication by calling one constructor from another. Code in this constructors was the same, so we can use this() keyword.