### PR TITLE
Modified the OpenAI endpoint for CreateCompetition

### DIFF
--- a/OpenAI.SDK/Managers/OpenAICompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAICompletions.cs
@@ -9,6 +9,12 @@ public partial class OpenAIService : ICompletionService
 {
     public async Task<CompletionCreateResponse> CreateCompletion(CompletionCreateRequest createCompletionRequest, string? engineId = null)
     {
-        return await _httpClient.PostAndReadAsAsync<CompletionCreateResponse>(_endpointProvider.CompletionCreate(ProcessEngineId(engineId)), createCompletionRequest);
+        // if I don't have an engine I use the new endpoint
+        CompletionCreateResponse response =
+            !string.IsNullOrEmpty(createCompletionRequest.Model)
+                        ? await _httpClient.PostAndReadAsAsync<CompletionCreateResponse>(_endpointProvider.CompletionCreate(), createCompletionRequest)
+                        : await _httpClient.PostAndReadAsAsync<CompletionCreateResponse>(_endpointProvider.CompletionCreate(ProcessEngineId(engineId)), createCompletionRequest);
+
+        return response;
     }
 }

--- a/OpenAI.SDK/OpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/OpenAiEndpointProvider.cs
@@ -3,6 +3,7 @@
     internal interface IOpenAiEndpointProvider
     {
         string ModelRetrieve(string model);
+        string CompletionCreate();
         string CompletionCreate(string engineId);
         string EditCreate();
         string ModelsList();
@@ -40,6 +41,18 @@
         public string FileDelete(string fileId)
         {
             return $"/{_apiVersion}/files/{fileId}";
+        }
+
+        /* 
+         *   From Documentation 
+         *   https://help.openai.com/en/articles/6283125-what-happened-to-engines
+         *   after June 6, 2022 
+         *   What happened to ‘engines’?
+         *   We are deprecating the term ‘engine’ in favor of ‘model’. Most people already use these terms interchangeably, and we consistently hear that ‘model’ is more intuitive. 
+         */
+        public string CompletionCreate()
+        {
+            return $"/{_apiVersion}/completions";
         }
 
         public string CompletionCreate(string engineId)


### PR DESCRIPTION
since the endpoint for calling completions has changed, I have included the ability to call without passing the engine that was previously required.
I also left the old signature for backward compatibility