### PR TITLE
readme edits / combo test / html builder / command-line

### DIFF
--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -39,7 +39,7 @@ var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 //////await FineTuningTestHelper.CleanUpAllFineTunings(sdk); //!!!!! will delete all fine-tunings
 //await FineTuningTestHelper.RunCaseStudyIsTheModelMakingUntrueStatements(sdk);
 
-await ComboTestHelper.RunSimpleCompletionImageTest(sdk, "Once upon a time");
+await ComboTestHelper.RunSimpleComboTest(sdk, "Once upon a time");
 
 Console.WriteLine("Press ENTER to exit.");
 

--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -5,6 +5,8 @@ using OpenAI.GPT3.Extensions;
 using OpenAI.GPT3.Interfaces;
 using OpenAI.Playground.TestHelpers;
 
+var commandLineArgs = Environment.GetCommandLineArgs();
+
 var builder = new ConfigurationBuilder()
     .AddJsonFile("ApiSettings.json")
     .AddUserSecrets<Program>();
@@ -24,6 +26,20 @@ serviceCollection.AddOpenAIService();
 var serviceProvider = serviceCollection.BuildServiceProvider();
 var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 
+var prompt = string.Empty;
+var imageCount = 1;
+foreach (var commandLineArg in commandLineArgs)
+{
+    if (commandLineArg.StartsWith("--prompt:"))
+    {
+        prompt = commandLineArg.Replace("--prompt:","").Replace("\"","");
+    }
+    if (commandLineArg.StartsWith("--imagecount:"))
+    {
+        int.TryParse(commandLineArg.Replace("--imagecount:", ""),out imageCount);
+    }
+}
+
 //await ModelTestHelper.FetchModelsTest(sdk);
 //await EditTestHelper.RunSimpleEditCreateTest(sdk);
 //await ImageTestHelper.RunSimpleCreateImageTest(sdk);
@@ -39,7 +55,7 @@ var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 //////await FineTuningTestHelper.CleanUpAllFineTunings(sdk); //!!!!! will delete all fine-tunings
 //await FineTuningTestHelper.RunCaseStudyIsTheModelMakingUntrueStatements(sdk);
 
-await ComboTestHelper.RunSimpleComboTest(sdk, "Once upon a time");
+await ComboTestHelper.RunSimpleComboTest(sdk, prompt, imageCount);
 
 Console.WriteLine("Press ENTER to exit.");
 

--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -33,9 +33,14 @@ var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 //await CompletionTestHelper.RunSimpleCompletionTest(sdk);
 //await CompletionTestHelper.RunSimpleCompletionTest2(sdk);
 //await CompletionTestHelper.RunSimpleCompletionTest3(sdk);
-await CompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
+//await CompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
 //await EmbeddingTestHelper.RunSimpleEmbeddingTest(sdk);
 //////await FileTestHelper.RunSimpleFileTest(sdk); //will delete files
 //////await FineTuningTestHelper.CleanUpAllFineTunings(sdk); //!!!!! will delete all fine-tunings
 //await FineTuningTestHelper.RunCaseStudyIsTheModelMakingUntrueStatements(sdk);
+
+await ComboTestHelper.RunSimpleCompletionImageTest(sdk, "Once upon a time");
+
+Console.WriteLine("Press ENTER to exit.");
+
 Console.ReadLine();

--- a/OpenAI.Playground/Properties/launchSettings.json
+++ b/OpenAI.Playground/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "OpenAI.Playground": {
+      "commandName": "Project",
+      "commandLineArgs": "--prompt:\"jumping up and down like a\" --imagecount:3"
+    }
+  }
+}

--- a/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
@@ -12,14 +12,15 @@ namespace OpenAI.Playground.TestHelpers
         /// </summary>
         /// <param name="sdk"></param>
         /// <param name="completionPrompt"></param>
+        /// <param name="imageCount"></param>
         /// <returns></returns>
-        public static async Task RunSimpleComboTest(IOpenAIService sdk, string completionPrompt)
+        public static async Task RunSimpleComboTest(IOpenAIService sdk, string completionPrompt, int imageCount = 1)
         {
             ConsoleExtensions.WriteLine("Combo Completion/Image Test:", ConsoleColor.Cyan);
             try
             {
                 var imagePrompt = await CompletionTestHelper.RunSimpleCompletionStreamTest(sdk, completionPrompt);
-                var imageUrls = await ImageTestHelper.RunSimpleCreateImageTest(sdk, imagePrompt, 4);
+                var imageUrls = await ImageTestHelper.RunSimpleCreateImageTest(sdk, imagePrompt, imageCount);
                 var html = BuildHtml(completionPrompt, imagePrompt, imageUrls);
                 var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ComboCompletionImageTest.html");
                 await File.WriteAllTextAsync(path, html);
@@ -37,11 +38,17 @@ namespace OpenAI.Playground.TestHelpers
                 throw;
             }
         }
-
-        public static string BuildHtml(string completionPrompt, string imagePrompt, List<string> imageUrls)
+        /// <summary>
+        /// Builds the HTML to show the output in a browser
+        /// </summary>
+        /// <param name="completionPrompt"></param>
+        /// <param name="imagePrompt"></param>
+        /// <param name="imageUrls"></param>
+        /// <returns></returns>
+        private static string BuildHtml(string completionPrompt, string imagePrompt, List<string> imageUrls)
         {
             var body = $"<h1>Completion</h1>";
-            body += "<p><strong>The initial completion prompt was:</strong> {completionPrompt}</p>";
+            body += $"<p><strong>The initial completion prompt was:</strong> {completionPrompt}</p>";
             body += $"<p>This gave us the following full completion from OpenAI: {imagePrompt}</p>";
             body += $"<h1>Image Generation</h1>";
             body +=

--- a/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
@@ -1,0 +1,57 @@
+﻿using OpenAI.GPT3.Interfaces;
+using OpenAI.GPT3.ObjectModels;
+using OpenAI.GPT3.ObjectModels.RequestModels;
+using System.Diagnostics;
+
+namespace OpenAI.Playground.TestHelpers
+{
+    internal static class ComboTestHelper
+    {
+        /// <summary>
+        /// Runs a combo test with a prompt for the completion and then use the entire completion for image generation
+        /// </summary>
+        /// <param name="sdk"></param>
+        /// <param name="completionPrompt"></param>
+        /// <returns></returns>
+        public static async Task RunSimpleCompletionImageTest(IOpenAIService sdk, string completionPrompt)
+        {
+            ConsoleExtensions.WriteLine("Combo Completion/Image Test:", ConsoleColor.Cyan);
+            try
+            {
+                var imagePrompt = await CompletionTestHelper.RunSimpleCompletionStreamTest(sdk, completionPrompt);
+                var imageUrls = await ImageTestHelper.RunSimpleCreateImageTest(sdk, imagePrompt, 4);
+                var html = await BuildHtml(completionPrompt, imagePrompt, imageUrls);
+                var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ComboCompletionImageTest.html");
+                await File.WriteAllTextAsync(path, html);
+                Console.WriteLine("HTML file saved to " + path);
+
+                var uri = new Uri(path);
+                var url = uri.AbsoluteUri;
+
+                Process.Start(new ProcessStartInfo(url){UseShellExecute = true});
+
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+        }
+
+        public static async Task<string> BuildHtml(string completionPrompt, string imagePrompt, List<string> imageUrls)
+        {
+            var body = $"<h1>Completion</h1>";
+            body += "<p><strong>The initial completion prompt was:</strong> {completionPrompt}</p>";
+            body += $"<p>This gave us the following full completion from OpenAI: {imagePrompt}</p>";
+            body += $"<h1>Image Generation</h1>";
+            body +=
+                $"<p>We then fed the full completion into image generation as a prompt and got back the following images:</p>";
+            foreach (var imageUrl in imageUrls)
+            {
+                body += $"<img src={imageUrl} alt={imagePrompt}><br/>";
+            }
+            var html = $"<!DOCTYPE html>\n<html>\n<head>\n<title>{completionPrompt}</title>\n</head>\n<body>{body}</body>\n</html>";
+            return html;
+        }
+    }
+}

--- a/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
@@ -13,7 +13,7 @@ namespace OpenAI.Playground.TestHelpers
         /// <param name="sdk"></param>
         /// <param name="completionPrompt"></param>
         /// <returns></returns>
-        public static async Task RunSimpleCompletionImageTest(IOpenAIService sdk, string completionPrompt)
+        public static async Task RunSimpleComboTest(IOpenAIService sdk, string completionPrompt)
         {
             ConsoleExtensions.WriteLine("Combo Completion/Image Test:", ConsoleColor.Cyan);
             try

--- a/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ComboTestHelper.cs
@@ -20,7 +20,7 @@ namespace OpenAI.Playground.TestHelpers
             {
                 var imagePrompt = await CompletionTestHelper.RunSimpleCompletionStreamTest(sdk, completionPrompt);
                 var imageUrls = await ImageTestHelper.RunSimpleCreateImageTest(sdk, imagePrompt, 4);
-                var html = await BuildHtml(completionPrompt, imagePrompt, imageUrls);
+                var html = BuildHtml(completionPrompt, imagePrompt, imageUrls);
                 var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ComboCompletionImageTest.html");
                 await File.WriteAllTextAsync(path, html);
                 Console.WriteLine("HTML file saved to " + path);
@@ -38,7 +38,7 @@ namespace OpenAI.Playground.TestHelpers
             }
         }
 
-        public static async Task<string> BuildHtml(string completionPrompt, string imagePrompt, List<string> imageUrls)
+        public static string BuildHtml(string completionPrompt, string imagePrompt, List<string> imageUrls)
         {
             var body = $"<h1>Completion</h1>";
             body += "<p><strong>The initial completion prompt was:</strong> {completionPrompt}</p>";

--- a/OpenAI.Playground/TestHelpers/CompletionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/CompletionTestHelper.cs
@@ -123,24 +123,32 @@ namespace OpenAI.Playground.TestHelpers
             }
         }
 
-        public static async Task RunSimpleCompletionStreamTest(IOpenAIService sdk)
+        public static async Task<string> RunSimpleCompletionStreamTest(IOpenAIService sdk, string prompt = "Once upon a time")
         {
             ConsoleExtensions.WriteLine("Completion Stream Testing is starting:", ConsoleColor.Cyan);
 
             try
             {
                 ConsoleExtensions.WriteLine("Completion Stream Test:", ConsoleColor.DarkCyan);
-                var completionResult = sdk.Completions.CreateCompletionAsStream(new CompletionCreateRequest()
-                {
-                    Prompt = "Once upon a time",
-                    MaxTokens = 50
-                }, Models.Davinci);
 
+                var completionCreateRequest = new CompletionCreateRequest()
+                {
+                    Prompt = prompt,
+                    MaxTokens = 50
+                };
+
+                var completionResult = sdk.Completions.CreateCompletionAsStream(completionCreateRequest, Models.Davinci);
+
+                Console.Write($"[{prompt}] ");
+
+                var fullCompletionResult = prompt;
                 await foreach (var completion in completionResult)
                 {
                     if (completion.Successful)
                     {
-                        Console.Write(completion.Choices.FirstOrDefault()?.Text);
+                        var completionText = completion.Choices.FirstOrDefault()?.Text;
+                        Console.Write(completionText);
+                        fullCompletionResult += completionText;
                     }
                     else
                     {
@@ -155,6 +163,8 @@ namespace OpenAI.Playground.TestHelpers
 
                 Console.WriteLine("");
                 Console.WriteLine("Complete");
+
+                return fullCompletionResult;
             }
             catch (Exception e)
             {

--- a/OpenAI.Playground/TestHelpers/ImageTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ImageTestHelper.cs
@@ -6,7 +6,7 @@ namespace OpenAI.Playground.TestHelpers
 {
     internal static class ImageTestHelper
     {
-        public static async Task<List<string>> RunSimpleCreateImageTest(IOpenAIService sdk, string prompt = "Laser cat eyes", int n = 2)
+        public static async Task<List<string>> RunSimpleCreateImageTest(IOpenAIService sdk, string prompt = "Laser cat eyes", int imageCount = 2)
         {
             ConsoleExtensions.WriteLine("Image Create Testing is starting:", ConsoleColor.Cyan);
             var imageUrls = new List<string>();
@@ -17,7 +17,7 @@ namespace OpenAI.Playground.TestHelpers
                 var imageResult = await sdk.Image.CreateImage(new ImageCreateRequest
                 {
                     Prompt = prompt,
-                    N = n,
+                    N = imageCount,
                     Size = StaticValues.ImageStatics.Size.Size256,
                     ResponseFormat = StaticValues.ImageStatics.ResponseFormat.Url,
                     User = "TestUser"

--- a/OpenAI.Playground/TestHelpers/ImageTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ImageTestHelper.cs
@@ -6,17 +6,18 @@ namespace OpenAI.Playground.TestHelpers
 {
     internal static class ImageTestHelper
     {
-        public static async Task RunSimpleCreateImageTest(IOpenAIService sdk)
+        public static async Task<List<string>> RunSimpleCreateImageTest(IOpenAIService sdk, string prompt = "Laser cat eyes", int n = 2)
         {
             ConsoleExtensions.WriteLine("Image Create Testing is starting:", ConsoleColor.Cyan);
+            var imageUrls = new List<string>();
 
             try
             {
                 ConsoleExtensions.WriteLine("Image Create Test:", ConsoleColor.DarkCyan);
                 var imageResult = await sdk.Image.CreateImage(new ImageCreateRequest
                 {
-                    Prompt = "Laser cat eyes",
-                    N = 2,
+                    Prompt = prompt,
+                    N = n,
                     Size = StaticValues.ImageStatics.Size.Size256,
                     ResponseFormat = StaticValues.ImageStatics.ResponseFormat.Url,
                     User = "TestUser"
@@ -25,7 +26,14 @@ namespace OpenAI.Playground.TestHelpers
 
                 if (imageResult.Successful)
                 {
-                    Console.WriteLine(string.Join("\n", imageResult.Results.Select(r => r.Url)));
+                    Console.WriteLine("Image URLs:\n");
+                    foreach (var imageResultResult in imageResult.Results)
+                    {
+                        Console.WriteLine(imageResultResult.Url);
+                        Console.WriteLine("---");
+
+                        imageUrls.Add(imageResultResult.Url);
+                    }
                 }
                 else
                 {
@@ -42,6 +50,7 @@ namespace OpenAI.Playground.TestHelpers
                 Console.WriteLine(e);
                 throw;
             }
+            return imageUrls;
         }
 
         public static async Task RunSimpleCreateImageEditTest(IOpenAIService sdk)

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ var openAiService = new OpenAIService(new OpenAiOptions()
     ApiKey =  Environment.GetEnvironmentVariable("MY_OPEN_AI_API_KEY")
 });
 ```
-### Using dependcy injection:
+### Using dependency injection:
 #### secrets.json: 
 Your API Key comes from here --> https://beta.openai.com/account/api-keys
 

--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ Visit https://openai.com/ to get your API key. Also documentation with more deta
 The repository includes one sample project already **"OpenAI.Playground"** You can check playground project to see how I was testing it while I was developing the library. Be carefull while playing with it. Some test methods will delete your files or fine tunings.  
 
 
-### Without using dependcy injection:
+### Without using dependency injection:
 ```csharp
 var openAiService = new OpenAIService(new OpenAiOptions()
 {
@@ -42,6 +42,8 @@ var openAiService = new OpenAIService(new OpenAiOptions()
 ```
 ### Using dependcy injection:
 #### secrets.json: 
+Your API Key comes from here --> https://beta.openai.com/account/api-keys
+Your Organization ID comes from here --> https://beta.openai.com/account/org-settings
 
 ```csharp
  "OpenAIServiceOptions": {

--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,7 @@ var openAiService = new OpenAIService(new OpenAiOptions()
 ### Using dependcy injection:
 #### secrets.json: 
 Your API Key comes from here --> https://beta.openai.com/account/api-keys
+
 Your Organization ID comes from here --> https://beta.openai.com/account/org-settings
 
 ```csharp

--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,23 @@ if (imageResult.Successful)
 }
 ```
 
+## Combo Sample
+Added a sample to show how to take the response from a completion and feed into image generation (GPT-3 --> DALL-E)
+This also generates HTML to display prompts and images in user's default browser.
+```csharp
+// Program.cs
+await ComboTestHelper.RunSimpleComboTest(sdk, prompt, imageCount);
+```
+
+## Command-Line Switches
+NOTE: Currently command-line switches only work for the [Combo Sample](#combo-sample)
+
+When using in command-line, use the following switches:
+```
+--prompt:"A sample prompt is awesome because" // prompt to feed to combo test; currently only works on combo; must include quotes;
+--imagecount:3 // number of images to generate
+```
+
 ## Notes:
 I couldn't find enough time to test all the methods or improve the documentation. My main target was to make fine-tuning available. If you hit any issue please report it or pull request always appreciated. 
 


### PR DESCRIPTION
first pull request here. lmk if any changes are needed.

this one includes:
1. typo and addition for clarity to readme.md
2. addition of "combo test" that takes output from completion and sends to dall-e
3. combo test builds an html file and opens in default browser, makes it easier for user to see combined results (no copy/paste multiple urls)
4. takes prompt and number of images as command-line inputs, also added sample values to launchsettings.json