### PR TITLE
Fix OpenAIService.RetrieveFile not returning the correct data.

### DIFF
--- a/OpenAI.SDK/EndpointProviders/AzureOpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/EndpointProviders/AzureOpenAiEndpointProvider.cs
@@ -57,7 +57,7 @@ internal class AzureOpenAiEndpointProvider : IOpenAiEndpointProvider
 
     public string FileRetrieve(string fileId)
     {
-        return Files();
+        return $"/{Prefix}/files/{fileId}{QueryString}";
     }
 
     public string FineTuneCreate()

--- a/OpenAI.SDK/EndpointProviders/OpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/EndpointProviders/OpenAiEndpointProvider.cs
@@ -51,7 +51,7 @@ internal class OpenAiEndpointProvider : IOpenAiEndpointProvider
 
     public string FileRetrieve(string fileId)
     {
-        return Files();
+        return $"/{_apiVersion}/files/{fileId}";
     }
 
     public string FineTuneCreate()


### PR DESCRIPTION
The implementations of IOpenAiEndpointProvider incorrectly created the incorrect URI which causes the GetFromJsonAsync<FileResponse> to not work (as it gets list of files and not a single file result).