### PR TITLE
Add support for .Net Standard 2.0

### DIFF
--- a/OpenAI.SDK/Extensions/HttpclientExtensions.cs
+++ b/OpenAI.SDK/Extensions/HttpclientExtensions.cs
@@ -29,7 +29,13 @@ public static class HttpClientExtensions
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
         request.Content = content;
 
+#if NET6_0
         return client.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+#else
+        var responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        var response = responseTask.GetAwaiter().GetResult();
+        return response;
+#endif
     }
 
     public static async Task<TResponse> PostFileAndReadAsAsync<TResponse>(this HttpClient client, string uri, HttpContent content, CancellationToken cancellationToken = default)

--- a/OpenAI.SDK/Extensions/HttpclientExtensions.cs
+++ b/OpenAI.SDK/Extensions/HttpclientExtensions.cs
@@ -29,7 +29,7 @@ public static class HttpClientExtensions
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
         request.Content = content;
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         return client.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 #else
         var responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);

--- a/OpenAI.SDK/Extensions/StringExtensions.cs
+++ b/OpenAI.SDK/Extensions/StringExtensions.cs
@@ -6,7 +6,7 @@
 public static class StringExtensions
 {
     /// <summary>
-    ///     Remove the search string from the begging of string if exist
+    ///     Remove the search string from the beginning of string if it exists
     /// </summary>
     /// <param name="text"></param>
     /// <param name="search"></param>
@@ -14,6 +14,6 @@ public static class StringExtensions
     public static string RemoveIfStartWith(this string text, string search)
     {
         var pos = text.IndexOf(search, StringComparison.Ordinal);
-        return pos != 0 ? text : text[search.Length..];
+        return pos != 0 ? text : text.Substring(search.Length);
     }
 }

--- a/OpenAI.SDK/Interfaces/IChatCompletionService.cs
+++ b/OpenAI.SDK/Interfaces/IChatCompletionService.cs
@@ -26,16 +26,20 @@ public interface IChatCompletionService
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
     IAsyncEnumerable<ChatCompletionCreateResponse> CreateCompletionAsStream(ChatCompletionCreateRequest chatCompletionCreate, string? modelId = null, CancellationToken cancellationToken = default);
+}
 
+public static class IChatCompletionServiceExtension
+{
     /// <summary>
     ///     Creates a new completion for the provided prompt and parameters
     /// </summary>
+    /// <param name="service"></param>
     /// <param name="chatCompletionCreate"></param>
     /// <param name="modelId">The ID of the model to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<ChatCompletionCreateResponse> Create(ChatCompletionCreateRequest chatCompletionCreate, Models.Model modelId, CancellationToken cancellationToken = default)
+    public static Task<ChatCompletionCreateResponse> Create(this IChatCompletionService service, ChatCompletionCreateRequest chatCompletionCreate, Models.Model modelId, CancellationToken cancellationToken = default)
     {
-        return CreateCompletion(chatCompletionCreate, modelId.EnumToString(), cancellationToken);
+        return service.CreateCompletion(chatCompletionCreate, modelId.EnumToString(), cancellationToken);
     }
 }

--- a/OpenAI.SDK/Interfaces/IChatCompletionService.cs
+++ b/OpenAI.SDK/Interfaces/IChatCompletionService.cs
@@ -30,7 +30,7 @@ public interface IChatCompletionService
     /// <summary>
     ///     Creates a new completion for the provided prompt and parameters
     /// </summary>
-    /// <param name="createCompletionModel"></param>
+    /// <param name="chatCompletionCreate"></param>
     /// <param name="modelId">The ID of the model to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>

--- a/OpenAI.SDK/Interfaces/ICompletionService.cs
+++ b/OpenAI.SDK/Interfaces/ICompletionService.cs
@@ -27,16 +27,20 @@ public interface ICompletionService
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
     IAsyncEnumerable<CompletionCreateResponse> CreateCompletionAsStream(CompletionCreateRequest createCompletionModel, string? modelId = null, CancellationToken cancellationToken = default);
+}
 
+public static class ICompletionServiceExtension
+{
     /// <summary>
     ///     Creates a new completion for the provided prompt and parameters
     /// </summary>
+    /// <param name="service"></param>
     /// <param name="createCompletionModel"></param>
     /// <param name="modelId">The ID of the model to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<CompletionCreateResponse> Create(CompletionCreateRequest createCompletionModel, Models.Model modelId, CancellationToken cancellationToken = default)
+    public static Task<CompletionCreateResponse> Create(this ICompletionService service, CompletionCreateRequest createCompletionModel, Models.Model modelId, CancellationToken cancellationToken = default)
     {
-        return CreateCompletion(createCompletionModel, modelId.EnumToString(), cancellationToken);
+        return service.CreateCompletion(createCompletionModel, modelId.EnumToString(), cancellationToken);
     }
 }

--- a/OpenAI.SDK/Interfaces/IEditService.cs
+++ b/OpenAI.SDK/Interfaces/IEditService.cs
@@ -17,16 +17,20 @@ public interface IEditService
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
     Task<EditCreateResponse> CreateEdit(EditCreateRequest editCreate, string? modelId = null, CancellationToken cancellationToken = default);
+}
 
+public static class IEditServiceExtension
+{
     /// <summary>
     ///     Creates a new edit for the provided input, instruction, and parameters
     /// </summary>
+    /// <param name="service"></param>
     /// <param name="editCreate"></param>
     /// <param name="modelId">The ID of the model to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<EditCreateResponse> Edit(EditCreateRequest editCreate, Models.Model modelId, CancellationToken cancellationToken = default)
+    public static Task<EditCreateResponse> Edit(this IEditService service, EditCreateRequest editCreate, Models.Model modelId, CancellationToken cancellationToken = default)
     {
-        return CreateEdit(editCreate, modelId.EnumToString(), cancellationToken);
+        return service.CreateEdit(editCreate, modelId.EnumToString(), cancellationToken);
     }
 }

--- a/OpenAI.SDK/Interfaces/IFileService.cs
+++ b/OpenAI.SDK/Interfaces/IFileService.cs
@@ -35,21 +35,6 @@ public interface IFileService
     /// <returns></returns>
     Task<FileUploadResponse> UploadFile(string purpose, byte[] file, string fileName, CancellationToken cancellationToken = default);
 
-    Task<FileUploadResponse> FileUpload(string purpose, Stream file, string fileName, CancellationToken cancellationToken = default)
-    {
-        return UploadFile(purpose, file.ToByteArray(), fileName, cancellationToken);
-    }
-
-    Task<FileUploadResponse> FileUpload(UploadFilePurposes.UploadFilePurpose purpose, Stream file, string fileName, CancellationToken cancellationToken = default)
-    {
-        return UploadFile(purpose.EnumToString(), file.ToByteArray(), fileName, cancellationToken);
-    }
-
-    Task<FileUploadResponse> FileUpload(UploadFilePurposes.UploadFilePurpose purpose, byte[] file, string fileName, CancellationToken cancellationToken = default)
-    {
-        return UploadFile(purpose.EnumToString(), file, fileName, cancellationToken);
-    }
-
     /// <summary>
     ///     Delete a file.
     /// </summary>
@@ -72,16 +57,35 @@ public interface IFileService
     /// <param name="fileId">The ID of the file to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<FileContentResponse<string?>> RetrieveFileContent(string fileId, CancellationToken cancellationToken = default)
+    Task<FileContentResponse<T?>> RetrieveFileContent<T>(string fileId, CancellationToken cancellationToken = default);
+}
+
+public static class IFileServiceExtension
+{
+    public static Task<FileUploadResponse> FileUpload(this IFileService service, string purpose, Stream file, string fileName, CancellationToken cancellationToken = default)
     {
-        return RetrieveFileContent<string>(fileId, cancellationToken);
+        return service.UploadFile(purpose, file.ToByteArray(), fileName, cancellationToken);
+    }
+
+    public static Task<FileUploadResponse> FileUpload(this IFileService service, UploadFilePurposes.UploadFilePurpose purpose, Stream file, string fileName, CancellationToken cancellationToken = default)
+    {
+        return service.UploadFile(purpose.EnumToString(), file.ToByteArray(), fileName, cancellationToken);
+    }
+
+    public static Task<FileUploadResponse> FileUpload(this IFileService service, UploadFilePurposes.UploadFilePurpose purpose, byte[] file, string fileName, CancellationToken cancellationToken = default)
+    {
+        return service.UploadFile(purpose.EnumToString(), file, fileName, cancellationToken);
     }
 
     /// <summary>
     ///     Returns the contents of the specified file
     /// </summary>
+    /// <param name="service"></param>
     /// <param name="fileId">The ID of the file to use for this request</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<FileContentResponse<T?>> RetrieveFileContent<T>(string fileId, CancellationToken cancellationToken = default);
+    public static Task<FileContentResponse<string?>> RetrieveFileContent(this IFileService service, string fileId, CancellationToken cancellationToken = default)
+    {
+        return service.RetrieveFileContent<string>(fileId, cancellationToken);
+    }
 }

--- a/OpenAI.SDK/Interfaces/IImageService.cs
+++ b/OpenAI.SDK/Interfaces/IImageService.cs
@@ -18,17 +18,6 @@ public interface IImageService
     Task<ImageCreateResponse> CreateImage(ImageCreateRequest imageCreate, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     Creates an image given a prompt.
-    /// </summary>
-    /// <param name="prompt"></param>
-    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
-    /// <returns></returns>
-    Task<ImageCreateResponse> CreateImage(string prompt, CancellationToken cancellationToken = default)
-    {
-        return CreateImage(new ImageCreateRequest(prompt), cancellationToken);
-    }
-
-    /// <summary>
     ///     Creates an edited or extended image given an original image and a prompt.
     /// </summary>
     /// <param name="imageEditCreateRequest"></param>
@@ -43,4 +32,19 @@ public interface IImageService
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
     Task<ImageCreateResponse> CreateImageVariation(ImageVariationCreateRequest imageEditCreateRequest, CancellationToken cancellationToken = default);
+}
+
+public static class IImageServiceExtension
+{
+    /// <summary>
+    ///     Creates an image given a prompt.
+    /// </summary>
+    /// <param name="service"></param>
+    /// <param name="prompt"></param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns></returns>
+    public static Task<ImageCreateResponse> CreateImage(this IImageService service, string prompt, CancellationToken cancellationToken = default)
+    {
+        return service.CreateImage(new ImageCreateRequest(prompt), cancellationToken);
+    }
 }

--- a/OpenAI.SDK/Interfaces/IModerationService.cs
+++ b/OpenAI.SDK/Interfaces/IModerationService.cs
@@ -16,10 +16,14 @@ public interface IModerationService
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
     Task<CreateModerationResponse> CreateModeration(CreateModerationRequest createModerationRequest, CancellationToken cancellationToken = default);
+}
 
+public static class IModerationServiceExtension
+{
     /// <summary>
     ///     Classifies if text violates OpenAI's Content Policy
     /// </summary>
+    /// <param name="service"></param>
     /// <param name="input">The input text to classify</param>
     /// <param name="model">
     ///     Two content moderations models are available: text-moderation-stable and text-moderation-latest.
@@ -29,9 +33,9 @@ public interface IModerationService
     /// </param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<CreateModerationResponse> CreateModeration(string input, string? model = null, CancellationToken cancellationToken = default)
+    public static Task<CreateModerationResponse> CreateModeration(this IModerationService service, string input, string? model = null, CancellationToken cancellationToken = default)
     {
-        return CreateModeration(new CreateModerationRequest
+        return service.CreateModeration(new CreateModerationRequest
         {
             Input = input,
             Model = model

--- a/OpenAI.SDK/Managers/OpenAICompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAICompletions.cs
@@ -26,46 +26,64 @@ public partial class OpenAIService : ICompletionService
         createCompletionRequest.ProcessModelId(modelId, _defaultModelId);
 
         using var response = _httpClient.PostAsStreamAsync(_endpointProvider.CompletionCreate(), createCompletionRequest, cancellationToken);
-        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        using var reader = new StreamReader(stream);
-        // Continuously read the stream until the end of it
-        while (!reader.EndOfStream)
+        Stream? stream = null;
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var line = await reader.ReadLineAsync();
-            // Skip empty lines
-            if (string.IsNullOrEmpty(line))
+            stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var reader = new StreamReader(stream);
+            // Continuously read the stream until the end of it
+            while (!reader.EndOfStream)
             {
-                continue;
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var line = await reader.ReadLineAsync();
+                // Skip empty lines
+                if (string.IsNullOrEmpty(line))
+                {
+                    continue;
+                }
+
+                line = line.RemoveIfStartWith("data: ");
+
+                // Exit the loop if the stream is done
+                if (line.StartsWith("[DONE]"))
+                {
+                    break;
+                }
+
+                CompletionCreateResponse? block;
+                try
+                {
+                    // When the response is good, each line is a serializable CompletionCreateRequest
+                    block = JsonSerializer.Deserialize<CompletionCreateResponse>(line);
+                }
+                catch (Exception)
+                {
+                    // When the API returns an error, it does not come back as a block, it returns a single character of text ("{").
+                    // In this instance, read through the rest of the response, which should be a complete object to parse.
+                    line += await reader.ReadToEndAsync();
+                    block = JsonSerializer.Deserialize<CompletionCreateResponse>(line);
+                }
+
+
+                if (null != block)
+                {
+                    yield return block;
+                }
             }
-
-            line = line.RemoveIfStartWith("data: ");
-
-            // Exit the loop if the stream is done
-            if (line.StartsWith("[DONE]"))
+        }
+        finally
+        {
+            if (stream is not null)
             {
-                break;
-            }
-
-            CompletionCreateResponse? block;
-            try
-            {
-                // When the response is good, each line is a serializable CompletionCreateRequest
-                block = JsonSerializer.Deserialize<CompletionCreateResponse>(line);
-            }
-            catch (Exception)
-            {
-                // When the API returns an error, it does not come back as a block, it returns a single character of text ("{").
-                // In this instance, read through the rest of the response, which should be a complete object to parse.
-                line += await reader.ReadToEndAsync();
-                block = JsonSerializer.Deserialize<CompletionCreateResponse>(line);
-            }
-
-
-            if (null != block)
-            {
-                yield return block;
+                if (stream is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    stream.Dispose();
+                }
             }
         }
     }

--- a/OpenAI.SDK/OpenAI.GPT3.csproj
+++ b/OpenAI.SDK/OpenAI.GPT3.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>Latest</LangVersion>
 
 		<Copyright>Betalgo Up Ltd.</Copyright>
 		<PackageProjectUrl>https://openai.com/</PackageProjectUrl>
@@ -46,5 +47,8 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
 	</ItemGroup>
-
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+	</ItemGroup>
 </Project>

--- a/OpenAI.SDK/Tokenizer/GPT3/GPT3Settings.cs
+++ b/OpenAI.SDK/Tokenizer/GPT3/GPT3Settings.cs
@@ -17,7 +17,7 @@ internal static class TokenizerGpt3Settings
 
     private static Dictionary<Tuple<string, string>, int> BuildBpeRanks()
     {
-        var lines = EmbeddedResource.Read("vocab.bpe").Split("\n");
+        var lines = EmbeddedResource.Read("vocab.bpe").Split('\n');
         var bpeMerges = new ArraySegment<string>(lines, 1, lines.Length - 1)
             .Where(x => x.Trim().Length > 0)
             .Select(x =>


### PR DESCRIPTION
I have implemented backwards compatibility with .Net Standard 2.0 using a combination of:

* conditional compilation using pre-processor directives
* extension methods
* backwards compatible code changes

I have tried to minimize the changes to the .Net 6 codebase. I have also used many ideas from ricaun's earlier implementation. I have tried not to alter any method signatures.

I have broken it into multiple commits for easier review. The 2 biggest changes are:
* moving default implementations in interfaces into static extension classes (thanks ricaun for the implementation)
* replace 'await using' with a try/finally block