### PR TITLE
Rename `FromAssistance` to `FromAssistant`

### DIFF
--- a/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
@@ -19,7 +19,7 @@ internal static class ChatCompletionTestHelper
                 {
                     ChatMessage.FromSystem("You are a helpful assistant."),
                     ChatMessage.FromUser("Who won the world series in 2020?"),
-                    ChatMessage.FromAssistance("The Los Angeles Dodgers won the World Series in 2020."),
+                    ChatMessage.FromAssistant("The Los Angeles Dodgers won the World Series in 2020."),
                     ChatMessage.FromUser("Where was it played?")
                 },
                 MaxTokens = 50,

--- a/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
@@ -26,10 +26,13 @@ public class ChatMessage
     [JsonPropertyName("content")]
     public string Content { get; set; }
 
-    public static ChatMessage FromAssistance(string content)
+    public static ChatMessage FromAssistant(string content)
     {
         return new ChatMessage(StaticValues.ChatMessageRoles.Assistant, content);
     }
+
+    [Obsolete("Please use FromAssistant instead.")]
+    public static ChatMessage FromAssistance(string content) => FromAssistant(content);
 
     public static ChatMessage FromUser(string content)
     {


### PR DESCRIPTION
Rename `FromAssistance` to `FromAssistant`, keep `FromAssistance` around but marked as obsolete for backward compat.
Fixes #143.
