### PR TITLE
Implement true support for FineTuneListEvents stream=true parameter

### DIFF
--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -60,6 +60,8 @@ await AudioTestHelper.RunSimpleAudioCreateTranslationTest(sdk);
 //////await FileTestHelper.RunSimpleFileTest(sdk); //will delete all of your files
 //////await FineTuningTestHelper.CleanUpAllFineTunings(sdk); //!!!!! will delete all fine-tunings
 //await FineTuningTestHelper.RunCaseStudyIsTheModelMakingUntrueStatements(sdk);
+//await FineTuningTestHelper.RunCaseListFineTuneEvents(sdk);
+//await FineTuningTestHelper.RunCaseListFineTuneEventsStream(sdk);
 await TokenizerTestHelper.RunTokenizerTest();
 await TokenizerTestHelper.RunTokenizerTestCrClean();
 

--- a/OpenAI.SDK/EndpointProviders/AzureOpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/EndpointProviders/AzureOpenAiEndpointProvider.cs
@@ -85,8 +85,12 @@ internal class AzureOpenAiEndpointProvider : IOpenAiEndpointProvider
         return $"{Prefix}/fine-tunes/{fineTuneId}/cancel{QueryString}";
     }
 
-    public string FineTuneListEvents(string fineTuneId)
+    public string FineTuneListEvents(string fineTuneId, bool? stream)
     {
+        if (stream != null)
+        {
+            return $"{Prefix}/fine-tunes/{fineTuneId}/events{QueryString}&stream={stream}";
+        }
         return $"{Prefix}/fine-tunes/{fineTuneId}/events{QueryString}";
     }
 

--- a/OpenAI.SDK/EndpointProviders/IOpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/EndpointProviders/IOpenAiEndpointProvider.cs
@@ -15,7 +15,7 @@ internal interface IOpenAiEndpointProvider
     string FineTuneList();
     string FineTuneRetrieve(string fineTuneId);
     string FineTuneCancel(string fineTuneId);
-    string FineTuneListEvents(string fineTuneId);
+    string FineTuneListEvents(string fineTuneId, bool? stream);
     string FineTuneDelete(string fineTuneId);
     string EmbeddingCreate();
     string ModerationCreate();

--- a/OpenAI.SDK/EndpointProviders/OpenAiEndpointProvider.cs
+++ b/OpenAI.SDK/EndpointProviders/OpenAiEndpointProvider.cs
@@ -89,8 +89,12 @@ internal class OpenAiEndpointProvider : IOpenAiEndpointProvider
         return $"/{_apiVersion}/fine-tunes/{fineTuneId}/cancel";
     }
 
-    public string FineTuneListEvents(string fineTuneId)
+    public string FineTuneListEvents(string fineTuneId, bool? stream)
     {
+        if (stream != null)
+        {
+            return $"/{_apiVersion}/fine-tunes/{fineTuneId}/events?stream={stream}";
+        }
         return $"/{_apiVersion}/fine-tunes/{fineTuneId}/events";
     }
 

--- a/OpenAI.SDK/Interfaces/IFineTuneService.cs
+++ b/OpenAI.SDK/Interfaces/IFineTuneService.cs
@@ -1,5 +1,6 @@
 ﻿using OpenAI.GPT3.ObjectModels.RequestModels;
 using OpenAI.GPT3.ObjectModels.ResponseModels.FineTuneResponseModels;
+using OpenAI.GPT3.ObjectModels.SharedModels;
 
 namespace OpenAI.GPT3.Interfaces;
 
@@ -46,15 +47,17 @@ public interface IFineTuneService
     ///     Get fine-grained status updates for a fine-tune job.
     /// </summary>
     /// <param name="fineTuneId">The ID of the fine-tune job to get events for.</param>
-    /// <param name="stream">
-    ///     Whether to stream events for the fine-tune job. If set to true, events will be sent as data-only server-sent events
-    ///     as they become available. The stream will terminate with a data: [DONE] message when the job is finished
-    ///     (succeeded, cancelled, or failed).
-    ///     If set to false, only events generated so far will be returned.
-    /// </param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    Task<Stream> ListFineTuneEvents(string fineTuneId, bool? stream = null, CancellationToken cancellationToken = default);
+    Task<FineTuneListEventsResponse> ListFineTuneEvents(string fineTuneId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Get fine-grained status updates for a fine-tune job as a stream (blocks until a new event comes in).
+    /// </summary>
+    /// <param name="fineTuneId">The ID of the fine-tune job to get events for.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <returns></returns>
+    IAsyncEnumerable<EventResponse> ListFineTuneEventsStream(string fineTuneId, CancellationToken cancellationToken = default);
 
     Task DeleteFineTune(string fineTuneId, CancellationToken cancellationToken = default);
 }

--- a/OpenAI.SDK/Managers/OpenAIFineTune.cs
+++ b/OpenAI.SDK/Managers/OpenAIFineTune.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net.Http.Json;
+using System.Text.Json;
 using OpenAI.GPT3.Extensions;
 using OpenAI.GPT3.Interfaces;
 using OpenAI.GPT3.ObjectModels.RequestModels;
 using OpenAI.GPT3.ObjectModels.ResponseModels.FineTuneResponseModels;
+using OpenAI.GPT3.ObjectModels.SharedModels;
 
 namespace OpenAI.GPT3.Managers;
 
@@ -31,10 +33,73 @@ public partial class OpenAIService : IFineTuneService
         }, cancellationToken);
     }
 
-    public async Task<Stream> ListFineTuneEvents(string fineTuneId, bool? stream = null, CancellationToken cancellationToken = default)
+    public async Task<FineTuneListEventsResponse> ListFineTuneEvents(string fineTuneId, CancellationToken cancellationToken = default)
     {
-        return await _httpClient.GetStreamAsync(_endpointProvider.FineTuneListEvents(fineTuneId), cancellationToken);
-        //return await _httpClient.GetFromJsonAsync<ListFineTuneEventsResponse>(_endpointProvider.FineTuneListEvents(fineTuneId));
+        return (await _httpClient.GetFromJsonAsync<FineTuneListEventsResponse>(_endpointProvider.FineTuneListEvents(fineTuneId, false), cancellationToken))!;
+    }
+
+    public async IAsyncEnumerable<EventResponse> ListFineTuneEventsStream(string fineTuneId, CancellationToken cancellationToken = default)
+    {
+        var eventCount = 0;
+        var uriPath = _endpointProvider.FineTuneListEvents(fineTuneId, true);
+        var done = false;
+        while (!done)
+        {
+            await using var stream = await _httpClient.GetStreamAsync(uriPath, cancellationToken);
+            using var streamReader = new StreamReader(stream);
+            var currentEventCount = 0;
+            while (true)
+            {
+
+                var endOfStream = TryEndOfStreamOperation(streamReader);
+                if (!endOfStream.HasValue)
+                {
+                    break;
+                }
+                if (endOfStream.Value)
+                {
+                    done = true;
+                    break;
+                }
+
+                if (currentEventCount < eventCount)
+                {
+                    await streamReader.ReadLineAsync();
+                    currentEventCount++;
+                    continue;
+                }
+
+                currentEventCount++;
+                eventCount++;
+                var eventData = await streamReader.ReadLineAsync();
+
+                if (string.IsNullOrEmpty(eventData))
+                {
+                    continue;
+                }
+                var startJson = eventData.IndexOf('{');
+                var endJson = eventData.LastIndexOf('}');
+                if (startJson == -1 || endJson == -1)
+                {
+                    continue;
+                }
+
+                var json = eventData[startJson..(endJson + 1)];
+                yield return JsonSerializer.Deserialize<EventResponse>(json)!;
+            }
+        }
+    }
+
+    private bool? TryEndOfStreamOperation(StreamReader streamReader)
+    {
+        try
+        {
+            return streamReader.EndOfStream;
+        }
+        catch (IOException e) when(e.Message.Contains("The response ended prematurely", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
     }
 
     public async Task DeleteFineTune(string fineTuneId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Break the API to two functions:

Task<FineTuneListEventsResponse> ListFineTuneEvents(string fineTuneId, CancellationToken cancellationToken = default) non-streaming version that stops with all the events already generated.

IAsyncEnumerable<EventResponse> ListFineTuneEventsStream(string fineTuneId, CancellationToken cancellationToken = default) - streaming version that blocks until a the next event is generated.  It completes when there is no more events generated.

The streaming version is complex due to the fact that the request can fail with a IOException "The response ended prematurely" message when accessing the streamReader.EndOfStream value.  When this happens, it "restarts" the stream events request "skipping" the already returned events and continues the wait.