### PR TITLE
Supports configuring httpclient proxy urls

### DIFF
--- a/OpenAI.SDK/Managers/OpenAIService.cs
+++ b/OpenAI.SDK/Managers/OpenAIService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Options;
 using OpenAI.GPT3.EndpointProviders;
 using OpenAI.GPT3.Interfaces;
+using System.Net;
 
 namespace OpenAI.GPT3.Managers;
 
@@ -22,7 +23,19 @@ public partial class OpenAIService : IOpenAIService
     {
         settings.Validate();
 
-        _httpClient = httpClient ?? new HttpClient();
+        if (!string.IsNullOrWhiteSpace(settings.HttpProxy))
+        {
+            var handler = new HttpClientHandler()
+            {
+                Proxy = new WebProxy(settings.HttpProxy),
+                UseProxy = true
+            };
+            _httpClient = httpClient ?? new HttpClient(handler);
+        }
+        else
+        {
+            _httpClient = httpClient ?? new HttpClient();
+        }
         _httpClient.BaseAddress = new Uri(settings.BaseDomain);
 
         switch (settings.ProviderType)

--- a/OpenAI.SDK/Managers/OpenAIService.cs
+++ b/OpenAI.SDK/Managers/OpenAIService.cs
@@ -22,7 +22,6 @@ public partial class OpenAIService : IOpenAIService
     public OpenAIService(OpenAiOptions settings, HttpClient? httpClient = null)
     {
         settings.Validate();
-
         if (!string.IsNullOrWhiteSpace(settings.HttpProxy))
         {
             var handler = new HttpClientHandler()

--- a/OpenAI.SDK/OpenAiOptions.cs
+++ b/OpenAI.SDK/OpenAiOptions.cs
@@ -104,6 +104,11 @@ public class OpenAiOptions
     public string? ResourceName { get; set; }
 
     /// <summary>
+    /// Http Client Proxy Url
+    /// </summary>
+    public string? HttpProxy{ get; set; }
+
+    /// <summary>
     ///     Default model id. If you are working with only one model, this will save you from few line extra code.
     /// </summary>
     [Obsolete("Use Default Model Id")]


### PR DESCRIPTION
As shown in the submission, when the server is in a network segment isolated area, a proxy server can be configured to request to openai

For example, I installed the clash core on Linux with the proxy address localhost: 7890

Just configure HttpProxy=localhost: 7890