### PR TITLE
Fix AudioCreateTranscriptionResponse JSON serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains IDEs
+.idea

--- a/OpenAI.SDK/Managers/OpenAIAudioService.cs
+++ b/OpenAI.SDK/Managers/OpenAIAudioService.cs
@@ -50,7 +50,8 @@ public partial class OpenAIService : IAudioService
         }
 
 
-        if (StaticValues.AudioStatics.ResponseFormat.Json == audioCreateTranscriptionRequest.ResponseFormat ||
+        if (null == audioCreateTranscriptionRequest.ResponseFormat ||
+            StaticValues.AudioStatics.ResponseFormat.Json == audioCreateTranscriptionRequest.ResponseFormat ||
             StaticValues.AudioStatics.ResponseFormat.VerboseJson == audioCreateTranscriptionRequest.ResponseFormat)
         {
             return await _httpClient.PostFileAndReadAsAsync<AudioCreateTranscriptionResponse>(uri, multipartContent, cancellationToken);


### PR DESCRIPTION
The default value for `response_format` is `json` when omitted from the API call, so the response should be serialized from JSON when `audioCreateTranscriptionRequest.ResponseFormat` is `null`.

Fixes issue #221