### PR TITLE
Add `FileStream` property for audio file in addition to byte array

### DIFF
--- a/OpenAI.SDK/Managers/OpenAIAudioService.cs
+++ b/OpenAI.SDK/Managers/OpenAIAudioService.cs
@@ -26,6 +26,10 @@ public partial class OpenAIService : IAudioService
     {
         var multipartContent = new MultipartFormDataContent();
 
+        if (audioCreateTranscriptionRequest is {File: not null, FileStream: not null})
+        {
+            throw new ArgumentException("Either File or FileStream must be set, but not both.");
+        }
         if (audioCreateTranscriptionRequest.File != null)
         {
             multipartContent.Add(
@@ -42,11 +46,7 @@ public partial class OpenAIService : IAudioService
                 audioCreateTranscriptionRequest.FileName
             );
         }
-        else
-        {
-            throw new ArgumentException("File or FileStream must be set");
-        }
-        
+
         multipartContent.Add(new StringContent(audioCreateTranscriptionRequest.Model), "model");
         
         if (audioCreateTranscriptionRequest.Language != null)

--- a/OpenAI.SDK/Managers/OpenAIAudioService.cs
+++ b/OpenAI.SDK/Managers/OpenAIAudioService.cs
@@ -24,11 +24,27 @@ public partial class OpenAIService : IAudioService
 
     private async Task<AudioCreateTranscriptionResponse> Create(AudioCreateTranscriptionRequest audioCreateTranscriptionRequest, string uri, CancellationToken cancellationToken = default)
     {
-        var multipartContent = new MultipartFormDataContent
+        var multipartContent = new MultipartFormDataContent();
+
+        if (audioCreateTranscriptionRequest.File != null)
         {
-            {new ByteArrayContent(audioCreateTranscriptionRequest.File), "file", audioCreateTranscriptionRequest.FileName},
-            {new StringContent(audioCreateTranscriptionRequest.Model), "model"}
-        };
+            multipartContent.Add(
+                new ByteArrayContent(audioCreateTranscriptionRequest.File), 
+                "file",
+                audioCreateTranscriptionRequest.FileName
+            );
+        }
+        else if (audioCreateTranscriptionRequest.FileStream != null)
+        {
+            multipartContent.Add(
+                new StreamContent(audioCreateTranscriptionRequest.FileStream), 
+                "file",
+                audioCreateTranscriptionRequest.FileName
+            );
+        }
+        
+        multipartContent.Add(new StringContent(audioCreateTranscriptionRequest.Model), "model");
+        
         if (audioCreateTranscriptionRequest.Language != null)
         {
             multipartContent.Add(new StringContent(audioCreateTranscriptionRequest.Language), "language");

--- a/OpenAI.SDK/Managers/OpenAIAudioService.cs
+++ b/OpenAI.SDK/Managers/OpenAIAudioService.cs
@@ -42,6 +42,10 @@ public partial class OpenAIService : IAudioService
                 audioCreateTranscriptionRequest.FileName
             );
         }
+        else
+        {
+            throw new ArgumentException("File or FileStream must be set");
+        }
         
         multipartContent.Add(new StringContent(audioCreateTranscriptionRequest.Model), "model");
         

--- a/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
@@ -25,12 +25,12 @@ public record AudioCreateTranscriptionRequest : IModel, ITemperature, IFile
     /// <summary>
     ///     The audio file to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
     /// </summary>
-    public byte[] File { get; set; }
+    public byte[]? File { get; set; }
     
     /// <summary>
     ///     The stream of the audio file to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
     /// </summary>
-    public Stream FileStream { get; set; }
+    public Stream? FileStream { get; set; }
 
     /// <summary>
     ///     FileName

--- a/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
@@ -26,6 +26,11 @@ public record AudioCreateTranscriptionRequest : IModel, ITemperature, IFile
     ///     The audio file to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
     /// </summary>
     public byte[] File { get; set; }
+    
+    /// <summary>
+    ///     The stream of the audio file to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.
+    /// </summary>
+    public Stream FileStream { get; set; }
 
     /// <summary>
     ///     FileName

--- a/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
@@ -40,6 +40,7 @@ public interface IOpenAiModels
     public interface IFile
     {
         public byte[] File { get; set; }
+        public Stream FileStream { get; set; }
         public string FileName { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds a `FileStream` property so a `Stream` can be used instead of a byte array for the Whisper API.