### PR TITLE
Use `BindConfiguration` and avoid building a service provider.

### DIFF
--- a/OpenAI.SDK/Extensions/OpenAIServiceCollectionExtensions.cs
+++ b/OpenAI.SDK/Extensions/OpenAIServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using OpenAI.GPT3.Interfaces;
 using OpenAI.GPT3.Managers;
 
@@ -9,17 +8,15 @@ public static class OpenAIServiceCollectionExtensions
 {
     public static IHttpClientBuilder AddOpenAIService(this IServiceCollection services, Action<OpenAiOptions>? setupAction = null)
     {
-        if (setupAction == null)
+        var optionsBuilder = services.AddOptions<OpenAiOptions>();
+        if (setupAction != null)
         {
-            services.AddOptions<OpenAiOptions>();
+            optionsBuilder.Configure(setupAction);
         }
         else
         {
-            services.AddOptions<OpenAiOptions>().Configure(setupAction);
+            optionsBuilder.BindConfiguration(OpenAiOptions.SettingKey);
         }
-
-        var configuration = services.BuildServiceProvider().GetRequiredService<IConfiguration>();
-        services.Configure<OpenAiOptions>(configuration.GetSection(OpenAiOptions.SettingKey));
 
         return services.AddHttpClient<IOpenAIService, OpenAIService>();
     }


### PR DESCRIPTION
Instead of building a service provider from the current service collection to get the configuration, use the `BindConfiguration` method on the options builder.