### PR TITLE
A couple of small fixes for the 7.1 beta

### DIFF
--- a/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
@@ -23,7 +23,7 @@ internal static class ChatCompletionTestHelper
                     ChatMessage.FromUser("Where was it played?")
                 },
                 MaxTokens = 50,
-                Model = Models.ChatGpt3_5Turbo
+                Model = Models.Gpt_3_5_Turbo
             });
 
             if (completionResult.Successful)
@@ -63,7 +63,7 @@ internal static class ChatCompletionTestHelper
                     new(StaticValues.ChatMessageRoles.User, "Tell me a story about The Los Angeles Dodgers")
                 },
                 MaxTokens = 150,
-                Model = Models.ChatGpt3_5Turbo
+                Model = Models.Gpt_3_5_Turbo
             });
 
             await foreach (var completion in completionResult)
@@ -127,7 +127,7 @@ internal static class ChatCompletionTestHelper
                 // optionally, to force a specific function:
                 // FunctionCall = new Dictionary<string, string> { { "name", "get_current_weather" } },
                 MaxTokens = 50,
-                Model = Models.ChatGpt3_5Turbo_0613
+                Model = Models.Gpt_3_5_Turbo_0613
             });
 
             /*  expected output along the lines of:

--- a/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
@@ -108,6 +108,7 @@ public partial class OpenAIService : IChatCompletionService
             if (firstChoice == null) { return; } // not a valid state? nothing to do
 
             var isStreamingFnCall = IsStreamingFunctionCall();
+            var justStarted = false;
 
             // If we're not yet assembling, and we just got a streaming block that has a function_call segment,
             // this is the beginning of a function call assembly.
@@ -116,10 +117,12 @@ public partial class OpenAIService : IChatCompletionService
             {
                 FnCall = firstChoice.Message.FunctionCall;
                 firstChoice.Message.FunctionCall = null;
+                justStarted = true;
             }
 
             // As long as we're assembling, keep on appending those args
-            if (IsFnAssemblyActive)
+            // (Skip the first one, because it was already processed in the block above)
+            if (IsFnAssemblyActive && !justStarted)
             {
                 FnCall.Arguments += ExtractArgsSoFar();
             }

--- a/OpenAI.SDK/ObjectModels/Models.cs
+++ b/OpenAI.SDK/ObjectModels/Models.cs
@@ -67,14 +67,23 @@ public static class Models
         CodeCushmanV1,
 
         CodeDavinciV2,
-
+        [Obsolete("Use Gpt_3_5_Turbo instead")]
         ChatGpt3_5Turbo,
+        Gpt_3_5_Turbo,
+        [Obsolete("Use Gpt_3_5_Turbo_0301 instead")]
         ChatGpt3_5Turbo0301,
+        Gpt_3_5_Turbo_0301,
+
+        Gpt_3_5_Turbo_16k,
+        Gpt_3_5_Turbo_16k_0613,
+        Gpt_3_5_Turbo_0613,
 
         Gpt_4,
         Gpt_4_0314,
+        Gpt_4_0613,
         Gpt_4_32k,
         Gpt_4_32k_0314,
+        Gpt_4_32k_0613,
 
         WhisperV1
     }
@@ -135,7 +144,7 @@ public static class Models
     ///     and will be deprecated 3 months after a new version is released.	
     ///     32,768 tokens	Up to Sep 2021
     /// </summary>
-    public static string Gpt_32k_0613 => "gpt-4-32k-0613";
+    public static string Gpt_4_32k_0613 => "gpt-4-32k-0613";
 
 
     public static string Ada => "ada";
@@ -188,34 +197,48 @@ public static class Models
     ///     latest model iteration.
     ///     4,096 tokens	Up to Sep 2021
     /// </summary>
+    [Obsolete("Use Gpt_3_5_Turbo instead, this is just a naming change,the field will be removed in next versions")]
     public static string ChatGpt3_5Turbo => "gpt-3.5-turbo";
+    /// <summary>
+    ///     Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our
+    ///     latest model iteration.
+    ///     4,096 tokens	Up to Sep 2021
+    /// </summary>
+    public static string Gpt_3_5_Turbo => "gpt-3.5-turbo";
 
     /// <summary>
     ///     Same capabilities as the standard gpt-3.5-turbo model but with 4 times the context.	
     ///     16,384 tokens	Up to Sep 2021
     /// </summary>
-    public static string ChatGpt3_5Turbo_16k => "gpt-3.5-turbo-16k";
+    public static string Gpt_3_5_Turbo_16k => "gpt-3.5-turbo-16k";
 
     /// <summary>
     ///     Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo, this model will not receive updates, and will
     ///     only be supported for a three month period ending on June 1st 2023.
     ///     4,096 tokens	Up to Sep 2021
     /// </summary>
+    [Obsolete("Use Gpt_3_5_Turbo_0301 instead, this is just a naming change,the field will be removed in next versions")]
     public static string ChatGpt3_5Turbo0301 => "gpt-3.5-turbo-0301";
+    /// <summary>
+    ///     Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo, this model will not receive updates, and will
+    ///     only be supported for a three month period ending on June 1st 2023.
+    ///     4,096 tokens	Up to Sep 2021
+    /// </summary>
+    public static string Gpt_3_5_Turbo_0301 => "gpt-3.5-turbo-0301";
 
     /// <summary>
     ///     Snapshot of gpt-3.5-turbo from June 13th 2023 with function calling data. Unlike gpt-3.5-turbo, 
     ///     this model will not receive updates, and will be deprecated 3 months after a new version is released.	
     ///     4,096 tokens	Up to Sep 2021
     /// </summary>
-    public static string ChatGpt3_5Turbo_0613 => "gpt-3.5-turbo-0613";
+    public static string Gpt_3_5_Turbo_0613 => "gpt-3.5-turbo-0613";
 
     /// <summary>
     ///     Snapshot of gpt-3.5-turbo from June 13th 2023 with function calling data. Unlike gpt-3.5-turbo, 
     ///     this model will not receive updates, and will be deprecated 3 months after a new version is released.	
     ///     4,096 tokens	Up to Sep 2021
     /// </summary>
-    public static string ChatGpt3_5Turbo_16k_0613 => "gpt-3.5-turbo-16k-0613";
+    public static string Gpt_3_5_Turbo_16k_0613 => "gpt-3.5-turbo-16k-0613";
 
 
     public static string WhisperV1 => "whisper-1";
@@ -284,13 +307,20 @@ public static class Models
             Model.TextEditDavinciV1 => TextEditDavinciV1,
             Model.CodeEditDavinciV1 => CodeEditDavinciV1,
             Model.ChatGpt3_5Turbo => ChatGpt3_5Turbo,
+            Model.Gpt_3_5_Turbo => Gpt_3_5_Turbo,
             Model.ChatGpt3_5Turbo0301 => ChatGpt3_5Turbo0301,
+            Model.Gpt_3_5_Turbo_0301 => Gpt_3_5_Turbo_0301,
+            Model.Gpt_3_5_Turbo_0613 => Gpt_3_5_Turbo_0613,
+            Model.Gpt_3_5_Turbo_16k_0613 => Gpt_3_5_Turbo_16k_0613,
+            Model.Gpt_3_5_Turbo_16k => Gpt_3_5_Turbo_16k,
             Model.WhisperV1 => WhisperV1,
             Model.TextEmbeddingAdaV2 => TextEmbeddingAdaV2,
             Model.Gpt_4 => Gpt_4,
             Model.Gpt_4_0314 => Gpt_4_0314,
             Model.Gpt_4_32k => Gpt_4_32k,
             Model.Gpt_4_32k_0314 => Gpt_4_32k_0314,
+            Model.Gpt_4_0613 => Gpt_4_0613,
+            Model.Gpt_4_32k_0613 => Gpt_4_32k_0613,
             _ => throw new ArgumentOutOfRangeException(nameof(model), model, null)
         };
     }

--- a/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
@@ -169,6 +169,7 @@ public class FunctionParameterPropertyValue
     /// <summary>
     ///     Optional. List of allowed values for this argument.
     /// </summary>
+    [JsonPropertyName("enum")]
     public IList<string>? Enum { get; set; }
 }
 


### PR DESCRIPTION
- One JSON name annotation was missing
- Small fix for streamed argument string reconstruction: it assumed that the first arguments chunk was going to be an empty string, which has been empirically true so far, but might not be in the future.
