### PR TITLE
Fix FunctionDefinitionBuilder for function definition without parameters

### DIFF
--- a/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/ChatCompletionTestHelper.cs
@@ -112,6 +112,9 @@ internal static class ChatCompletionTestHelper
                 @enum: new List<string> { "celsius", "fahrenheit" })
             .AddParameter("num_days", "integer", "The number of days to forecast")
             .Build();
+        
+        var fn3 = new FunctionDefinitionBuilder("get_current_datetime", "Get the current date and time, e.g. 'Saturday, June 24, 2023 6:14:14 PM'")
+            .Build();
 
         try
         {
@@ -123,7 +126,7 @@ internal static class ChatCompletionTestHelper
                     ChatMessage.FromSystem("Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous."),
                     ChatMessage.FromUser("Give me a weather report for Chicago, USA, for the next 5 days."),
                 },
-                Functions = new List<FunctionDefinition> { fn1, fn2 },
+                Functions = new List<FunctionDefinition> { fn1, fn2, fn3 },
                 // optionally, to force a specific function:
                 // FunctionCall = new Dictionary<string, string> { { "name", "get_current_weather" } },
                 MaxTokens = 50,

--- a/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
@@ -187,7 +187,11 @@ public class FunctionDefinitionBuilder
         _definition = new()
         {
             Name = fnName,
-            Description = fnDescription
+            Description = fnDescription,
+            Parameters = new FunctionParameters
+            {
+                Properties = new Dictionary<string, FunctionParameterPropertyValue>()
+            }
         };
     }
 
@@ -222,10 +226,7 @@ public class FunctionDefinitionBuilder
         string name, string type, string? description = null,
         IList<string>? @enum = null, bool required = true)
     {
-        _definition.Parameters ??= new FunctionParameters();
-        _definition.Parameters.Properties ??= new Dictionary<string, FunctionParameterPropertyValue>();
-
-        _definition.Parameters.Properties[name] =
+        _definition.Parameters!.Properties![name] =
             new FunctionParameterPropertyValue() { Type = type, Description = description, Enum = @enum };
 
         if (required)


### PR DESCRIPTION
Function definitions without the `Parameters` property or `Parameters.Properties` property will make OpenAI API respond with an error.

For example, function:
```cs
new FunctionDefinitionBuilder(
    "get_current_datetime", 
    "Get the current date and time, e.g. 'Saturday, June 24, 2023 6:14:14 PM'"
).Build();
```
response: 
```
'parameters' is a required property - 'functions.0'
```

So I made these properties be assigned without adding parameters.