### PR TITLE
Enable to set FunctionCall to AssistantRole's ChatMessage

### DIFF
--- a/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ChatMessage.cs
@@ -49,9 +49,9 @@ public class ChatMessage
     [JsonPropertyName("function_call")]
     public FunctionCall? FunctionCall { get; set; }
 
-    public static ChatMessage FromAssistant(string content, string? name = null)
+    public static ChatMessage FromAssistant(string content, string? name = null, FunctionCall? functionCall = null)
     {
-        return new ChatMessage(StaticValues.ChatMessageRoles.Assistant, content, name);
+        return new ChatMessage(StaticValues.ChatMessageRoles.Assistant, content, name, functionCall);
     }
     public static ChatMessage FromFunction(string content, string? name = null)
     {


### PR DESCRIPTION
In the sample on the OpenAI website, FunctionCall is set in the AssistantRole's ChatMessage.
Whether it is necessary or not, it should be settable.
If my understanding is not sufficient or if you find this suggestion unnecessary, please feel free to close this pull request.

```
curl https://api.openai.com/v1/chat/completions -u :$OPENAI_API_KEY -H 'Content-Type: application/json' -d '{
  "model": "gpt-3.5-turbo-0613",
  "messages": [
    {"role": "user", "content": "What is the weather like in Boston?"},
    {"role": "assistant", "content": null, "function_call": {"name": "get_current_weather", "arguments": "{ \"location\": \"Boston, MA\"}"}},
    {"role": "function", "name": "get_current_weather", "content": "{\"temperature\": "22", \"unit\": \"celsius\", \"description\": \"Sunny\"}"}
  ],
  "functions": [
    {
      "name": "get_current_weather",
      "description": "Get the current weather in a given location",
      "parameters": {
        "type": "object",
        "properties": {
          "location": {
            "type": "string",
            "description": "The city and state, e.g. San Francisco, CA"
          },
          "unit": {
            "type": "string",
            "enum": ["celsius", "fahrenheit"]
          }
        },
        "required": ["location"]
      }
    }
  ]
}'
```