### PR TITLE
Add fallback method for HttpClient.Send on unsupported platforms

### DIFF
--- a/OpenAI.SDK/Extensions/HttpclientExtensions.cs
+++ b/OpenAI.SDK/Extensions/HttpclientExtensions.cs
@@ -30,12 +30,24 @@ public static class HttpClientExtensions
         request.Content = content;
 
 #if NET6_0_OR_GREATER
-        return client.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        try
+        {
+            return client.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return SendRequestPreNet6(client, request, cancellationToken);
+        }
 #else
+        return SendRequestPreNet6(client, request, cancellationToken);
+#endif
+    }
+
+    public static HttpResponseMessage SendRequestPreNet6(HttpClient client, HttpRequestMessage request, CancellationToken cancellationToken)
+    {
         var responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         var response = responseTask.GetAwaiter().GetResult();
         return response;
-#endif
     }
 
     public static async Task<TResponse> PostFileAndReadAsAsync<TResponse>(this HttpClient client, string uri, HttpContent content, CancellationToken cancellationToken = default)


### PR DESCRIPTION
In this commit, I have introduced error handling to manage the `PlatformNotSupportedException` that arises when calling HttpClient.Send in the PostAsStreamAsync method.

This exception occurs because of the HttpClient.Send method is not supported on certain platforms (in my case I was testing on MAUI, Mac Platform). To manage this, I have added a try-catch block to catch the PlatformNotSupportedException and then fall back to the SendRequestPreNet6 method, which uses HttpClient.SendAsync.