### PR TITLE
Override default timeout

### DIFF
--- a/OpenAI.SDK/Managers/OpenAIService.cs
+++ b/OpenAI.SDK/Managers/OpenAIService.cs
@@ -26,7 +26,7 @@ public partial class OpenAIService : IOpenAIService, IDisposable
         if (httpClient == null)
         {
             _disposeHttpClient = true;
-            _httpClient = new HttpClient();
+            _httpClient = new HttpClient() {Timeout = settings.Timeout};
         }
         else
         {

--- a/OpenAI.SDK/OpenAiOptions.cs
+++ b/OpenAI.SDK/OpenAiOptions.cs
@@ -121,6 +121,11 @@ public class OpenAiOptions
     public string? DefaultModelId { get; set; }
 
     /// <summary>
+    ///     Default timeout in which API has to respond
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>
     ///     Create an instance of this class with the necessary information to connect to the azure open ai api
     /// </summary>
     /// <param name="resourceName">Resource Name of your Azure OpenAI resource</param>


### PR DESCRIPTION
Default timeout on httpclient is 100 seconds, which is certainly to long for many applications.
I've setup a default value of 3 seconds which seems reasonable and given the option to the user to override it.

Not tested though.