### PR TITLE
Ignore lines that start with : ping 

### DIFF
--- a/OpenAI.SDK/Interfaces/IChatCompletionService.cs
+++ b/OpenAI.SDK/Interfaces/IChatCompletionService.cs
@@ -23,9 +23,10 @@ public interface IChatCompletionService
     /// </summary>
     /// <param name="modelId">The ID of the model to use for this request</param>
     /// <param name="chatCompletionCreate"></param>
+    /// <param name="justDataMode">Ignore stream lines if they don’t start with "data:". If you don't know what it means, probably you shouldn't change this.</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns></returns>
-    IAsyncEnumerable<ChatCompletionCreateResponse> CreateCompletionAsStream(ChatCompletionCreateRequest chatCompletionCreate, string? modelId = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<ChatCompletionCreateResponse> CreateCompletionAsStream(ChatCompletionCreateRequest chatCompletionCreate, string? modelId = null, bool justDataMode = true,CancellationToken cancellationToken = default);
 }
 
 public static class IChatCompletionServiceExtension

--- a/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
@@ -17,7 +17,7 @@ public partial class OpenAIService : IChatCompletionService
     }
 
     /// <inheritdoc />
-    public async IAsyncEnumerable<ChatCompletionCreateResponse> CreateCompletionAsStream(ChatCompletionCreateRequest chatCompletionCreateRequest, string? modelId = null,
+    public async IAsyncEnumerable<ChatCompletionCreateResponse> CreateCompletionAsStream(ChatCompletionCreateRequest chatCompletionCreateRequest, string? modelId = null, bool justDataMode = true,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Helper data in case we need to reassemble a multi-packet response
@@ -39,10 +39,16 @@ public partial class OpenAIService : IChatCompletionService
             cancellationToken.ThrowIfCancellationRequested();
 
             var line = await reader.ReadLineAsync();
+            
             // Skip empty lines
-            if (string.IsNullOrEmpty(line) || line.StartsWith(": ping"))
+            if (string.IsNullOrEmpty(line))
             {
                 continue;
+            }
+
+            if (justDataMode && !line.StartsWith("data: "))
+            {
+                ;
             }
 
             line = line.RemoveIfStartWith("data: ");

--- a/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
@@ -48,7 +48,7 @@ public partial class OpenAIService : IChatCompletionService
 
             if (justDataMode && !line.StartsWith("data: "))
             {
-                ;
+                continue;
             }
 
             line = line.RemoveIfStartWith("data: ");

--- a/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
+++ b/OpenAI.SDK/Managers/OpenAIChatCompletions.cs
@@ -40,7 +40,7 @@ public partial class OpenAIService : IChatCompletionService
 
             var line = await reader.ReadLineAsync();
             // Skip empty lines
-            if (string.IsNullOrEmpty(line))
+            if (string.IsNullOrEmpty(line) || line.StartsWith(": ping"))
             {
                 continue;
             }


### PR DESCRIPTION
When testing the client with streaming chat, I noticed the JSON parser crashes for lines that start at with ": ping", I believe its because the api sends chunks with event: ping which needs to be ignored