### PR TITLE
Add dimensions to EmbeddingCreateRequest

### DIFF
--- a/OpenAI.SDK/ObjectModels/Models.cs
+++ b/OpenAI.SDK/ObjectModels/Models.cs
@@ -56,6 +56,8 @@ public static class Models
         CodeEditDavinciV1,
 
         TextEmbeddingAdaV2,
+        TextEmbeddingV3Small,
+        TextEmbeddingV3Large,
 
         CodeSearchAdaCodeV1,
         CodeSearchBabbageCodeV1,
@@ -80,6 +82,7 @@ public static class Models
         Gpt_3_5_Turbo_16k_0613,
         Gpt_3_5_Turbo_0613,
         Gpt_3_5_Turbo_1106,
+        Gpt_3_5_Turbo_0125,
         Gpt_3_5_Turbo_Instruct,
 
         Gpt_4,
@@ -89,7 +92,9 @@ public static class Models
         Gpt_4_32k_0314,
         Gpt_4_32k_0613,
         Gpt_4_1106_preview,
+        Gpt_4_0125_preview,
         Gpt_4_vision_preview,
+        Gpt_4_turbo_preview,
 
         WhisperV1,
 
@@ -97,7 +102,11 @@ public static class Models
         Dall_e_3,
 
         Tts_1,
-        Tts_1_hd
+        Tts_1_hd,
+
+        Text_moderation_007,
+        Text_moderation_latest,
+        Text_moderation_stable,
     }
 
     public enum Subject
@@ -113,7 +122,8 @@ public static class Models
         Code,
         CodeEdit,
         Edit,
-        TextEmbedding
+        TextEmbedding,
+        TextModeration
     }
 
     /// <summary>
@@ -166,13 +176,16 @@ public static class Models
     /// </summary>
     public static string Gpt_4_1106_preview => "gpt-4-1106-preview";
 
+    public static string Gpt_4_0125_preview => "gpt-4-0125-preview";
     /// <summary>
     ///     Ability to understand images, in addition to all other GPT-4 Turbo capabilties.
     ///     Returns a maximum of 4,096 output tokens. This is a preview model version and not suited yet for production traffic.
     ///     128,000 tokens	Up to Apr 2023
     /// </summary>
     public static string Gpt_4_vision_preview => "gpt-4-vision-preview";
-    
+
+    public static string Gpt_4_turbo_preview => "gpt-4-turbo-preview";
+
 
 
     public static string Ada => "ada";
@@ -219,7 +232,12 @@ public static class Models
     public static string CodeSearchBabbageTextV1 => ModelNameBuilder(BaseModel.Babbage, Subject.CodeSearchText, "001");
 
     public static string TextEmbeddingAdaV2 => ModelNameBuilder(BaseModel.Ada, Subject.TextEmbedding, "002");
+    public static string TextEmbeddingV3Small => ModelNameBuilder(BaseModel.Ada, Subject.TextEmbedding, "3-small");
+    public static string TextEmbeddingV3Large => ModelNameBuilder(BaseModel.Ada, Subject.TextEmbedding, "3-large");
 
+    public static string TextModeration007 => ModelNameBuilder(BaseModel.Ada, Subject.TextModeration, "007");
+    public static string TextModerationLatest => ModelNameBuilder(BaseModel.Ada, Subject.TextModeration, "latest");
+    public static string TextModerationStable => ModelNameBuilder(BaseModel.Ada, Subject.TextModeration, "stable");
     /// <summary>
     ///     Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our
     ///     latest model iteration.
@@ -269,6 +287,7 @@ public static class Models
     /// </summary>
     public static string Gpt_3_5_Turbo_1106 => "gpt-3.5-turbo-1106";
 
+    public static string Gpt_3_5_Turbo_0125 => "gpt-3.5-turbo-0125";
     /// <summary>
     ///     Snapshot of gpt-3.5-turbo from June 13th 2023 with function calling data. Unlike gpt-3.5-turbo,
     ///     this model will not receive updates, and will be deprecated 3 months after a new version is released.
@@ -376,11 +395,14 @@ public static class Models
             Model.Gpt_3_5_Turbo_0301 => Gpt_3_5_Turbo_0301,
             Model.Gpt_3_5_Turbo_0613 => Gpt_3_5_Turbo_0613,
             Model.Gpt_3_5_Turbo_1106 => Gpt_3_5_Turbo_1106,
+            Model.Gpt_3_5_Turbo_0125 => Gpt_3_5_Turbo_0125,
             Model.Gpt_3_5_Turbo_16k_0613 => Gpt_3_5_Turbo_16k_0613,
             Model.Gpt_3_5_Turbo_16k => Gpt_3_5_Turbo_16k,
             Model.Gpt_3_5_Turbo_Instruct => Gpt_3_5_Turbo_Instruct,
             Model.WhisperV1 => WhisperV1,
             Model.TextEmbeddingAdaV2 => TextEmbeddingAdaV2,
+            Model.TextEmbeddingV3Small => TextEmbeddingV3Small,
+            Model.TextEmbeddingV3Large => TextEmbeddingV3Large,
             Model.Gpt_4 => Gpt_4,
             Model.Gpt_4_0314 => Gpt_4_0314,
             Model.Gpt_4_32k => Gpt_4_32k,
@@ -390,9 +412,14 @@ public static class Models
             Model.Dall_e_2 => Dall_e_2,
             Model.Dall_e_3 => Dall_e_3,
             Model.Gpt_4_1106_preview => Gpt_4_1106_preview,
+            Model.Gpt_4_0125_preview => Gpt_4_0125_preview,
             Model.Gpt_4_vision_preview => Gpt_4_vision_preview,
+            Model.Gpt_4_turbo_preview => Gpt_4_turbo_preview,
             Model.Tts_1 => Tts_1,
             Model.Tts_1_hd => Tts_1_hd,
+            Model.Text_moderation_007 => TextModeration007,
+            Model.Text_moderation_latest => TextModerationLatest,
+            Model.Text_moderation_stable => TextModerationStable,
             _ => throw new ArgumentOutOfRangeException(nameof(model), model, null)
         };
     }
@@ -427,6 +454,7 @@ public static class Models
             Subject.CodeEdit => "code-{0}-edit",
             Subject.Edit => "text-{0}-edit",
             Subject.TextEmbedding => "text-embedding-{0}",
+            Subject.TextModeration => "text-moderation-{0}",
             _ => throw new ArgumentOutOfRangeException(nameof(subject), subject, null)
         }, baseModel);
     }

--- a/OpenAI.SDK/ObjectModels/RequestModels/EmbeddingCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/EmbeddingCreateRequest.cs
@@ -66,6 +66,13 @@ public record EmbeddingCreateRequest : IModelValidate, IOpenAiModels.IModel
     [JsonPropertyName("dimensions")]
     public int? Dimensions { get; set; }
 
+    /// <summary>
+    /// The format to return the embeddings in. Can be either float or base64.
+    /// </summary>
+    /// <returns></returns>
+    [JsonPropertyName("encoding_format")]
+    public string? EncodingFormat { get; set; }
+
     public IEnumerable<ValidationResult> Validate()
     {
         throw new NotImplementedException();

--- a/OpenAI.SDK/ObjectModels/RequestModels/EmbeddingCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/EmbeddingCreateRequest.cs
@@ -59,6 +59,13 @@ public record EmbeddingCreateRequest : IModelValidate, IOpenAiModels.IModel
     [JsonPropertyName("model")]
     public string? Model { get; set; }
 
+    /// <summary>
+    ///     The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+    /// </summary>
+    /// <see href="https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions" />
+    [JsonPropertyName("dimensions")]
+    public int? Dimensions { get; set; }
+
     public IEnumerable<ValidationResult> Validate()
     {
         throw new NotImplementedException();


### PR DESCRIPTION
From https://openai.com/blog/new-embedding-models-and-api-updates
Add support for embedding v3 models where are can optionally specify the vector dimension size now.

See https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions