### PR TITLE
Fixed a bug that Vision API could not be used with Azure OpenAI

### DIFF
--- a/OpenAI.SDK/ObjectModels/RequestModels/MessageContent.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/MessageContent.cs
@@ -70,7 +70,7 @@ public class MessageContent
             ImageUrl = new()
             {
                 Url = string.Format(
-                    "data:image/{0};base64,{{{1}}}",
+                    "data:image/{0};base64,{1}",
                     imageType,
                     Convert.ToBase64String(binaryImage)
                 ),


### PR DESCRIPTION
When attempting to use the Vision API with Azure OpenAI, the following error occurs.

```
Invalid image (base64) data.
```

This pull request fixes the issue.