### PR TITLE
Streaming fixes.

### DIFF
--- a/OpenAI.Playground/OpenAI.Playground.csproj
+++ b/OpenAI.Playground/OpenAI.Playground.csproj
@@ -56,6 +56,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<None Update="ApiSettings.Development.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="ApiSettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/OpenAI.Playground/OpenAI.Playground.csproj
+++ b/OpenAI.Playground/OpenAI.Playground.csproj
@@ -56,9 +56,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="ApiSettings.Development.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
 		<None Update="ApiSettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -7,6 +7,7 @@ using LaserCatEyes.HttpClientListener;
 
 var builder = new ConfigurationBuilder()
     .AddJsonFile("ApiSettings.json")
+    .AddJsonFile("ApiSettings.Development.json")
     .AddUserSecrets<Program>();
 
 IConfiguration configuration = builder.Build();
@@ -41,6 +42,8 @@ var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 //  |   / \   / \   | \  /)  |    ( \  /o\  / )    |  (\  / |   / \   / \   |
 //  |-----------------------------------------------------------------------|
 
+await ChatCompletionTestHelper.RunChatFunctionCallTestAsStream(sdk);
+return;
 await ChatCompletionTestHelper.RunSimpleChatCompletionTest(sdk);
 //await ChatCompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
 

--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using LaserCatEyes.HttpClientListener;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenAI.Extensions;
 using OpenAI.Interfaces;
 using OpenAI.Playground.TestHelpers;
-using LaserCatEyes.HttpClientListener;
 
-var builder = new ConfigurationBuilder()
-    .AddJsonFile("ApiSettings.json")
-    .AddJsonFile("ApiSettings.Development.json")
+var builder = new ConfigurationBuilder().AddJsonFile("ApiSettings.json")
     .AddUserSecrets<Program>();
 
 IConfiguration configuration = builder.Build();
@@ -20,7 +18,7 @@ serviceCollection.AddScoped(_ => configuration);
 serviceCollection.AddLaserCatEyesHttpClientListener();
 
 //if you want to use beta services you have to set UseBeta to true. Otherwise, it will use the stable version of OpenAI apis.
-serviceCollection.AddOpenAIService(r=>r.UseBeta = true);
+serviceCollection.AddOpenAIService(r => r.UseBeta = true);
 
 //serviceCollection.AddOpenAIService();
 //// DeploymentId and ResourceName are only for Azure OpenAI. If you want to use Azure OpenAI services you have to set Provider type To Azure.
@@ -42,8 +40,6 @@ var sdk = serviceProvider.GetRequiredService<IOpenAIService>();
 //  |   / \   / \   | \  /)  |    ( \  /o\  / )    |  (\  / |   / \   / \   |
 //  |-----------------------------------------------------------------------|
 
-await ChatCompletionTestHelper.RunChatFunctionCallTestAsStream(sdk);
-return;
 await ChatCompletionTestHelper.RunSimpleChatCompletionTest(sdk);
 //await ChatCompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
 
@@ -68,6 +64,7 @@ await ChatCompletionTestHelper.RunSimpleChatCompletionTest(sdk);
 // Tools
 //await ChatCompletionTestHelper.RunChatFunctionCallTest(sdk);
 //await ChatCompletionTestHelper.RunChatFunctionCallTestAsStream(sdk);
+//await ChatCompletionTestHelper.RunSimpleCompletionStreamWithUsageTest(sdk);
 //await BatchTestHelper.RunBatchOperationsTest(sdk);
 
 // Whisper

--- a/OpenAI.SDK/Extensions/HttpclientExtensions.cs
+++ b/OpenAI.SDK/Extensions/HttpclientExtensions.cs
@@ -123,7 +123,7 @@ internal static class HttpClientExtensions
         return await HandleResponseContent<TResponse>(response, cancellationToken);
     }
 
-    private static async Task<TResponse> HandleResponseContent<TResponse>(this HttpResponseMessage response, CancellationToken cancellationToken) where TResponse : BaseResponse, new()
+    public static async Task<TResponse> HandleResponseContent<TResponse>(this HttpResponseMessage response, CancellationToken cancellationToken) where TResponse : BaseResponse, new()
     {
         TResponse result;
 
@@ -144,7 +144,14 @@ internal static class HttpClientExtensions
         }
 
         result.HttpStatusCode = response.StatusCode;
-        result.HeaderValues = new()
+        result.HeaderValues = response.ParseHeaders();
+
+        return result;
+    }
+
+    public static ResponseHeaderValues ParseHeaders(this HttpResponseMessage response)
+    {
+        return new ResponseHeaderValues()
         {
             Date = response.Headers.Date,
             Connection = response.Headers.Connection?.ToString(),
@@ -181,7 +188,6 @@ internal static class HttpClientExtensions
                 Version = response.Headers.GetHeaderValue("openai-version")
             }
         };
-        return result;
     }
 
 #if NETSTANDARD2_0

--- a/OpenAI.SDK/ObjectModels/RequestModels/ChatCompletionCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ChatCompletionCreateRequest.cs
@@ -45,6 +45,12 @@ public class ChatCompletionCreateRequest : IModelValidate, IOpenAiModels.ITemper
     public bool? Stream { get; set; }
 
     /// <summary>
+    ///     Options for streaming response. Only set this when you set <see cref="Stream"/>: <c>true</c>.
+    /// </summary>
+    [JsonPropertyName("stream_options")]
+    public StreamOptions? StreamOptions { get; set; }
+
+    /// <summary>
     ///     Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop
     ///     sequence.
     /// </summary>

--- a/OpenAI.SDK/ObjectModels/RequestModels/StreamOptions.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/StreamOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace OpenAI.ObjectModels.RequestModels;
+
+/// <summary>
+///     Options for streaming response.
+/// </summary>
+public sealed class StreamOptions
+{
+    /// <summary>
+    ///     If set, an additional chunk will be streamed before the done message. 
+    /// </summary>
+    /// <remarks>
+    ///     This usage field on this chunk shows the token usage statistics for the entire request, and the choices field will always be an empty array.   
+    /// </remarks>
+    [JsonPropertyName("include_usage")]
+    public bool IncludeUsage { get; set; }
+}


### PR DESCRIPTION
Hi,

I solved a few issues around streaming:

1. Chat completion has a parameter to also return usage data. I think this should be added:
https://github.com/betalgo/openai/compare/master...SebastianStehle:openai:streaming-fixes?expand=1#diff-7723ad521684e749392e631a6e44d0ce3f33cdae5c9af2466e7bc52428dd7c37R50

2. Chat completion and completions has actually no error handling in place. This was also the root cause of my issue #556.

3. Chat completion response did not contain the same header information as the normal API. I have added the parsing here.

4. Something weird. OpenAI does not set the role of the response chunks to assistant. Therefore you cannot add the message directly to the context as you would do in a non-streaming scenario. Therefore I added a workaround for that to be the 2 endpoints more similar: https://github.com/betalgo/openai/compare/master...SebastianStehle:openai:streaming-fixes?expand=1#diff-d34076ca61932bc94550bf6bf3aeba9c9a2cf9508251ca2182e11683d9c98a5fR141

I have also extended the playground to make actual tool calls. I think the playground should be converted to an integration tests project. You do not have to add that to the CI, but it would be great to have something better.

Btw: I also added 2 places of a old school null comparison `if (block != null)`.

I hope we can get that out asap.

