### PR TITLE
Feature/assistant file ids stability

### DIFF
--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenAI.Extensions;
 using OpenAI.Interfaces;
 using OpenAI.Playground.TestHelpers;
+using OpenAI.Playground.TestHelpers.AssistantHelpers;
 
 var builder = new ConfigurationBuilder().AddJsonFile("ApiSettings.json")
     .AddUserSecrets<Program>();
@@ -48,7 +49,8 @@ await ChatCompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
 //await AssistantTestHelper.ThreadsTestHelper.RunTests(sdk);
 //await AssistantTestHelper.MessagesTestHelper.RunTests(sdk);
 //await AssistantTestHelper.RunTestHelper.RunTests(sdk);
-//await AssistantTestHelper.VectorTestHelper.RunTests(sdk);
+//await AssistantTestHelper.VectorTestHelper.RunTests(sd
+//await AssistantTestHelper3.RunTests(sdk);
 
 // Vision
 //await VisionTestHelper.RunSimpleVisionTest(sdk);

--- a/OpenAI.Playground/Program.cs
+++ b/OpenAI.Playground/Program.cs
@@ -54,6 +54,7 @@ await ChatCompletionTestHelper.RunSimpleCompletionStreamTest(sdk);
 
 // Vision
 //await VisionTestHelper.RunSimpleVisionTest(sdk);
+//await VisionTestHelper.RunSimpleVisionTestUsingBase64EncodedImage(sdk);
 //await VisionTestHelper.RunSimpleVisionStreamTest(sdk);
 //await VisionTestHelper.RunSimpleVisionTestUsingBase64EncodedImage(sdk);
 

--- a/OpenAI.Playground/TestHelpers/AssistantHelpers/VectorTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/AssistantHelpers/VectorTestHelper.cs
@@ -502,11 +502,11 @@ internal static partial class AssistantTestHelper
 
         private static async Task Cleanup(IOpenAIService sdk)
         {
-        
-            if (!string.IsNullOrWhiteSpace(CreatedVectorFileId))
+            if (!string.IsNullOrWhiteSpace(CreatedVectorFileId) && !string.IsNullOrWhiteSpace(CreatedVectorId))
             {
                 await sdk.Beta.VectorStoreFiles.DeleteVectorStoreFile(CreatedVectorId, CreatedVectorFileId);
             }
+
             if (!string.IsNullOrWhiteSpace(CreatedFileId1))
             {
                 await sdk.Files.DeleteFile(CreatedFileId1);

--- a/OpenAI.Playground/TestHelpers/VisionTestHelper.cs
+++ b/OpenAI.Playground/TestHelpers/VisionTestHelper.cs
@@ -2,6 +2,8 @@ using OpenAI.Interfaces;
 using OpenAI.ObjectModels;
 using OpenAI.ObjectModels.RequestModels;
 using OpenAI.Playground.ExtensionsAndHelpers;
+using System.Text.Json.Serialization;
+using System.Text.Json;
 using static OpenAI.ObjectModels.StaticValues;
 
 namespace OpenAI.Playground.TestHelpers;
@@ -127,6 +129,9 @@ internal static class VisionTestHelper
 
         try
         {
+
+            ConsoleExtensions.WriteLine("Vision Test With EncodedImage:", ConsoleColor.DarkCyan);
+
             ConsoleExtensions.WriteLine(
                 "Vision with base64 encoded image Test:",
                 ConsoleColor.DarkCyan
@@ -137,10 +142,7 @@ internal static class VisionTestHelper
                 $"SampleData/{originalFileName}"
             );
 
-            var completionResult = await sdk.ChatCompletion.CreateCompletion(
-                new ChatCompletionCreateRequest
-                {
-                    Messages = new List<ChatMessage>
+            var messages = new List<ChatMessage>
                     {
                         ChatMessage.FromSystem("You are an image analyzer assistant."),
                         ChatMessage.FromUser(
@@ -154,7 +156,22 @@ internal static class VisionTestHelper
                                 )
                             }
                         ),
-                    },
+                    };
+
+            /* DEBUG
+            var options = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            var serialized = JsonSerializer.Serialize(messages, options);
+            ConsoleExtensions.WriteLine($"MessageRequest: {serialized}", ConsoleColor.White);
+            */
+
+            var completionResult = await sdk.ChatCompletion.CreateCompletion(
+                new ChatCompletionCreateRequest
+                {
+                    Messages = messages,
                     MaxTokens = 300,
                     Model = Models.Gpt_4_vision_preview,
                     N = 1

--- a/OpenAI.SDK/ObjectModels/Models.cs
+++ b/OpenAI.SDK/ObjectModels/Models.cs
@@ -270,6 +270,7 @@ public static class Models
     public static string TextModeration007 => ModelNameBuilder(BaseModel.None, Subject.TextModeration, "007");
     public static string TextModerationLatest => ModelNameBuilder(BaseModel.None, Subject.TextModeration, "latest");
     public static string TextModerationStable => ModelNameBuilder(BaseModel.None, Subject.TextModeration, "stable");
+
     /// <summary>
     ///     Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003. Will be updated with our
     ///     latest model iteration.

--- a/OpenAI.SDK/ObjectModels/RequestModels/AssistantCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/AssistantCreateRequest.cs
@@ -3,7 +3,8 @@ using OpenAI.ObjectModels.SharedModels;
 
 namespace OpenAI.ObjectModels.RequestModels;
 
-public class AssistantCreateRequest : IOpenAiModels.IModel, IOpenAiModels.IFileIds, IOpenAiModels.IMetaData, IOpenAiModels.ITemperature
+// REMOVED: drp052424 - IOpenAiModels.IFileIds property is no longer in the API reference, and will not work if you use it
+public class AssistantCreateRequest : IOpenAiModels.IModel, IOpenAiModels.IMetaData, IOpenAiModels.ITemperature
 {
     /// <summary>
     ///     The name of the assistant. The maximum length is 256 characters.
@@ -64,12 +65,6 @@ public class AssistantCreateRequest : IOpenAiModels.IModel, IOpenAiModels.IFileI
     /// </summary>
     [JsonPropertyName("response_format")]
     public ResponseFormatOneOfType? ResponseFormat { get; set; }
-
-    /// <summary>
-    ///     A list of file IDs attached to this assistant.
-    /// </summary>
-    [JsonPropertyName("file_ids")]
-    public List<string>? FileIds { get; set; }
 
     /// <summary>
     ///     Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information

--- a/OpenAI.SDK/ObjectModels/RequestModels/AssistantCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/AssistantCreateRequest.cs
@@ -67,6 +67,13 @@ public class AssistantCreateRequest : IOpenAiModels.IModel, IOpenAiModels.IMetaD
     public ResponseFormatOneOfType? ResponseFormat { get; set; }
 
     /// <summary>
+    ///     A list of file IDs attached to this assistant.
+    /// </summary>
+    [JsonPropertyName("file_ids")]
+    [Obsolete("This field is no longer supported by the API.")]
+    public List<string>? FileIds { get; set; }
+
+    /// <summary>
     ///     Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information
     ///     about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of
     ///     512 characters long.

--- a/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/AudioCreateTranscriptionRequest.cs
@@ -42,7 +42,7 @@ public record AudioCreateTranscriptionRequest : IOpenAiModels.IModel, IOpenAiMod
     public Stream? FileStream { get; set; }
 
     /// <summary>
-    ///     FileName
+    ///     FileName.  Note the API keys off the extension of the FileName to know the format.
     /// </summary>
     public string FileName { get; set; }
 

--- a/OpenAI.SDK/ObjectModels/RequestModels/MessageCreateRequest.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/MessageCreateRequest.cs
@@ -49,12 +49,13 @@ public class MessageCreateRequest : IOpenAiModels.IMetaData
 public class Attachment
 {
     /// <summary>
-    /// The ID of the file to attach to
+    /// The ID of the file to attach to. See https://platform.openai.com/docs/assistants/tools/file-search/supported-files for a list of supported file extensions.
     /// </summary>
     [JsonPropertyName("file_id")]
     public string FileId { get; set; }
+
     /// <summary>
-    /// The tools to add this file to.
+    /// The tools to add this file to.  This is required and may contain CodeInterpreter and/or FileSearch
     /// </summary>
     [JsonPropertyName("tools")]
     public List<ToolDefinition> Tools { get; set; }

--- a/OpenAI.SDK/ObjectModels/RequestModels/VisionImageUrl.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/VisionImageUrl.cs
@@ -41,7 +41,7 @@ public class MessageImageFile
     /// <summary>
     /// The File ID of the image in the message content. Set purpose="vision" when uploading the File if you need to later display the file content.
     /// </summary>
-    [JsonPropertyName("file_Id")]
+    [JsonPropertyName("file_id")]
     public string FileId { get; set; }
     /// <summary>
     /// Specifies the detail level of the image if specified by the user. low uses fewer tokens, you can opt in to high resolution using high.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/CreateModerationResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/CreateModerationResponse.cs
@@ -9,7 +9,7 @@ public record CreateModerationResponse : BaseResponse, IOpenAiModels.IModel, IOp
 
     [JsonPropertyName("id")] public string Id { get; set; }
 
-    [JsonPropertyName("model")] public string Model { get; set; }
+    [JsonPropertyName("model")] public string? Model { get; set; }
 }
 
 public record Result

--- a/OpenAI.SDK/ObjectModels/UploadFilePurposes.cs
+++ b/OpenAI.SDK/ObjectModels/UploadFilePurposes.cs
@@ -4,22 +4,30 @@ public static class UploadFilePurposes
 {
     public enum UploadFilePurpose
     {
-        FineTune,
-        FineTuneResults,
         Assistants,
+        Vision,
+        Batch,
+        FineTune,
+        [Obsolete("Not supported by the API")]
+        FineTuneResults
     }
 
-    public const string FineTune = "fine-tune";
-    public const string FineTuneResults = "fine-tune-results";
+    // REF: https://platform.openai.com/docs/api-reference/files/create
     public const string Assistants = "assistants";
+    public const string Vision = "vision";
+    public const string Batch = "batch";
+    public const string FineTune = "fine-tune";
+    [Obsolete("Not supported by the API")]
+    public const string FineTuneResults = "fine-tune-results";
 
     public static string EnumToString(this UploadFilePurpose uploadFilePurpose)
     {
         return uploadFilePurpose switch
         {
-            UploadFilePurpose.FineTune => FineTune,
-            UploadFilePurpose.FineTuneResults => FineTuneResults,
             UploadFilePurpose.Assistants => Assistants,
+            UploadFilePurpose.Vision => Vision,
+            UploadFilePurpose.Batch => Batch,
+            UploadFilePurpose.FineTune => FineTune,
             _ => throw new ArgumentOutOfRangeException(nameof(uploadFilePurpose), uploadFilePurpose, null)
         };
     }
@@ -28,9 +36,10 @@ public static class UploadFilePurposes
     {
         return filePurpose switch
         {
-            FineTune => UploadFilePurpose.FineTune,
-            FineTuneResults => UploadFilePurpose.FineTuneResults,
             Assistants => UploadFilePurpose.Assistants,
+            Vision => UploadFilePurpose.Vision,
+            Batch => UploadFilePurpose.Batch,
+            FineTune => UploadFilePurpose.FineTune,
             _ => throw new ArgumentOutOfRangeException(nameof(filePurpose), filePurpose, null)
         };
     }


### PR DESCRIPTION
+ Files
- Fixed MessageContent.ImageFileContent request serialization
- Updated Purpose enum to match API (adding vision, batch)
- Marked AssistantCreateRequest.FileIds as obsolete
+ Tests:
- added MessagesTestHelper.CreateMessageWithImage() 
- Fixed Assistant test with Attachments
+ Audio: updated some field descriptions