### PR TITLE
feat: add required as tool choice

### DIFF
--- a/OpenAI.SDK/ObjectModels/RequestModels/ToolChoiceFunction.cs
+++ b/OpenAI.SDK/ObjectModels/RequestModels/ToolChoiceFunction.cs
@@ -7,6 +7,7 @@ public class ToolChoice
 {
     public static ToolChoice None => new() { Type = StaticValues.CompletionStatics.ToolChoiceType.None };
     public static ToolChoice Auto => new() { Type = StaticValues.CompletionStatics.ToolChoiceType.Auto };
+    public static ToolChoice Required => new() { Type = StaticValues.CompletionStatics.ToolChoiceType.Required };
 
     /// <summary>
     ///     "none" is the default when no functions are present.  <br />

--- a/OpenAI.SDK/ObjectModels/StaticValueHelper.cs
+++ b/OpenAI.SDK/ObjectModels/StaticValueHelper.cs
@@ -21,6 +21,7 @@ public class StaticValues
             public static string Function => ToolType.Function;
             public static string Auto => "auto";
             public static string None => "none";
+            public static string Required => "required";
         }
     }
 


### PR DESCRIPTION
Per [docs](https://platform.openai.com/docs/guides/function-calling), this should be supported.

Didn't find any usages of None being part of any tests so unsure if you feel adding a test here is needed.