### PR TITLE
Add Cached Tokens to UsageResponse

### DIFF
--- a/OpenAI.SDK/ObjectModels/ResponseModels/PromptTokensDetails.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/PromptTokensDetails.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace OpenAI.ObjectModels.ResponseModels
+{
+    public class PromptTokensDetails
+    {
+        [JsonPropertyName("cached_tokens")]
+        public int? CachedTokens { get; set; }
+    }
+}
+

--- a/OpenAI.SDK/ObjectModels/ResponseModels/UsageResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/UsageResponse.cs
@@ -15,4 +15,8 @@ public record UsageResponse
 
     [JsonPropertyName("completion_tokens_details")]
     public CompletionTokensDetails? CompletionTokensDetails { get; set; }
+
+    [JsonPropertyName("prompt_tokens_details")]
+    public PromptTokensDetails? PromptTokensDetails { get; set; }
+
 }


### PR DESCRIPTION
Openai Api has added  prompt caching : https://openai.com/index/api-prompt-caching/
This has added new property to the usage response returned this contain the number of tokens that where retrieved from the cache. 
Here is the example from the docs
usage: {
  total_tokens: 2306,
  prompt_tokens: 2006,
  completion_tokens: 300,
  
  prompt_tokens_details: {
    cached_tokens: 1920,
    audio_tokens: 0,
  },
  completion_tokens_details: {
    reasoning_tokens: 0,
    audio_tokens: 0,
  }
}

I have added a new class for prompt_tokens_details with property cached_tokens . The prompt_tokens_details has been added as a property of usage.
