### PR TITLE
Feature/fixed created at type

### DIFF
--- a/OpenAI.SDK/ObjectModels/ResponseModels/BatchResponseModel/BatchResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/BatchResponseModel/BatchResponse.cs
@@ -53,7 +53,12 @@ public record BatchResponse : BaseResponse, IOpenAIModels.IMetaData
     ///     The Unix timestamp (in seconds) for when the batch was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///    DateTimeOffset for when the batch was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The Unix timestamp (in seconds) for when the batch started processing.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/BatchResponseModel/BatchResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/BatchResponseModel/BatchResponse.cs
@@ -53,7 +53,7 @@ public record BatchResponse : BaseResponse, IOpenAIModels.IMetaData
     ///     The Unix timestamp (in seconds) for when the batch was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The Unix timestamp (in seconds) for when the batch started processing.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/ChatCompletionCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/ChatCompletionCreateResponse.cs
@@ -38,7 +38,10 @@ public record ChatCompletionCreateResponse : BaseResponse, IOpenAIModels.IId, IO
     [JsonPropertyName("service_tier")]
     public string? ServiceTier { get; set; }
 
-    [JsonPropertyName("created")] public long CreatedAt { get; set; }
+    [JsonPropertyName("created")]
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     A unique identifier for the chat completion.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/ChatCompletionCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/ChatCompletionCreateResponse.cs
@@ -38,11 +38,7 @@ public record ChatCompletionCreateResponse : BaseResponse, IOpenAIModels.IId, IO
     [JsonPropertyName("service_tier")]
     public string? ServiceTier { get; set; }
 
-    /// <summary>
-    ///     The Unix timestamp (in seconds) of when the chat completion was created.
-    /// </summary>
-    [JsonPropertyName("created")]
-    public int CreatedAt { get; set; }
+    [JsonPropertyName("created")] public long CreatedAt { get; set; }
 
     /// <summary>
     ///     A unique identifier for the chat completion.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/CompletionCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/CompletionCreateResponse.cs
@@ -14,7 +14,10 @@ public record CompletionCreateResponse : BaseResponse, IOpenAIModels.IId, IOpenA
     [JsonPropertyName("usage")]
     public UsageResponse Usage { get; set; }
 
-    [JsonPropertyName("created")] public long CreatedAt { get; set; }
+    [JsonPropertyName("created")]
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     [JsonPropertyName("id")]
     public string Id { get; set; }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/CompletionCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/CompletionCreateResponse.cs
@@ -14,8 +14,7 @@ public record CompletionCreateResponse : BaseResponse, IOpenAIModels.IId, IOpenA
     [JsonPropertyName("usage")]
     public UsageResponse Usage { get; set; }
 
-    [JsonPropertyName("created")]
-    public int CreatedAt { get; set; }
+    [JsonPropertyName("created")] public long CreatedAt { get; set; }
 
     [JsonPropertyName("id")]
     public string Id { get; set; }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/EditCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/EditCreateResponse.cs
@@ -14,5 +14,8 @@ public record EditCreateResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("usage")]
     public UsageResponse Usage { get; set; }
 
-    [JsonPropertyName("created")] public long CreatedAt { get; set; }
+    [JsonPropertyName("created")]
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/EditCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/EditCreateResponse.cs
@@ -14,6 +14,5 @@ public record EditCreateResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("usage")]
     public UsageResponse Usage { get; set; }
 
-    [JsonPropertyName("created")]
-    public int CreatedAt { get; set; }
+    [JsonPropertyName("created")] public long CreatedAt { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FileResponseModels/FileUploadResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FileResponseModels/FileUploadResponse.cs
@@ -17,5 +17,8 @@ public record FileUploadResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("purpose")]
     public string Purpose { get; set; }
 
-    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
+    [JsonPropertyName("created_at")]
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FileResponseModels/FileUploadResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FileResponseModels/FileUploadResponse.cs
@@ -17,6 +17,5 @@ public record FileUploadResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("purpose")]
     public string Purpose { get; set; }
 
-    [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FineTuneResponseModels/FineTuneResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FineTuneResponseModels/FineTuneResponse.cs
@@ -35,8 +35,8 @@ public record FineTuneResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.
     [JsonPropertyName("created_at")]
     public int CreatedAt { get; set; }
 
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
+    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
+    [JsonPropertyName("id")] public string Id { get; set; }
 
     [JsonPropertyName("model")]
     public string Model { get; set; }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FineTuneResponseModels/FineTuneResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FineTuneResponseModels/FineTuneResponse.cs
@@ -33,10 +33,12 @@ public record FineTuneResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.
     public int? UpdatedAt { get; set; }
 
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
 
-    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
-    [JsonPropertyName("id")] public string Id { get; set; }
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
 
     [JsonPropertyName("model")]
     public string Model { get; set; }

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FineTuningJobResponseModels/FineTuningJobResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FineTuningJobResponseModels/FineTuningJobResponse.cs
@@ -67,7 +67,7 @@ public record FineTuningJobResponse : BaseResponse, IOpenAIModels.IId, IOpenAIMo
     ///     The Unix timestamp (in seconds) for when the fine-tuning job was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The object identifier, which can be referenced in the API endpoints.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/FineTuningJobResponseModels/FineTuningJobResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/FineTuningJobResponseModels/FineTuningJobResponse.cs
@@ -67,7 +67,12 @@ public record FineTuningJobResponse : BaseResponse, IOpenAIModels.IId, IOpenAIMo
     ///     The Unix timestamp (in seconds) for when the fine-tuning job was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///     for when the fine-tuning job was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The object identifier, which can be referenced in the API endpoints.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/ImageResponseModel/ImageCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/ImageResponseModel/ImageCreateResponse.cs
@@ -8,8 +8,7 @@ public record ImageCreateResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("data")]
     public List<ImageDataResult> Results { get; set; }
 
-    [JsonPropertyName("created")]
-    public int CreatedAt { get; set; }
+    [JsonPropertyName("created")] public long CreatedAt { get; set; }
 
     public record ImageDataResult
     {

--- a/OpenAI.SDK/ObjectModels/ResponseModels/ImageResponseModel/ImageCreateResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/ImageResponseModel/ImageCreateResponse.cs
@@ -8,7 +8,9 @@ public record ImageCreateResponse : BaseResponse, IOpenAIModels.ICreatedAt
     [JsonPropertyName("data")]
     public List<ImageDataResult> Results { get; set; }
 
-    [JsonPropertyName("created")] public long CreatedAt { get; set; }
+    [JsonPropertyName("created")]
+    public long CreatedAtUnix { get; set; }  
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     public record ImageDataResult
     {

--- a/OpenAI.SDK/ObjectModels/ResponseModels/RunStepListResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/RunStepListResponse.cs
@@ -93,7 +93,9 @@ public record RunStepResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.I
     ///     The Unix timestamp (in seconds) for when the run step was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The identifier of the run step, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/RunStepListResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/RunStepListResponse.cs
@@ -93,7 +93,7 @@ public record RunStepResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.I
     ///     The Unix timestamp (in seconds) for when the run step was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The identifier of the run step, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileBatchObject.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileBatchObject.cs
@@ -15,7 +15,11 @@ public record VectorStoreFileBatchObject : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store files batch was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+    /// <summary>
+    ///     for when the vector store files batch was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files)

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileBatchObject.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileBatchObject.cs
@@ -15,7 +15,7 @@ public record VectorStoreFileBatchObject : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store files batch was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files)

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileObject.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileObject.cs
@@ -26,7 +26,12 @@ public record VectorStoreFileObject : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store file was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///     for when the vector store file was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files)

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileObject.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreFileObject.cs
@@ -26,7 +26,7 @@ public record VectorStoreFileObject : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store file was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The ID of the [vector store](/docs/api-reference/vector-stores/object) that the [File](/docs/api-reference/files)

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreObjectResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreObjectResponse.cs
@@ -15,7 +15,12 @@ public record VectorStoreObjectResponse : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///     for when the vector store was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The name of the vector store.

--- a/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreObjectResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/VectorStoreResponseModels/VectorStoreObjectResponse.cs
@@ -15,7 +15,7 @@ public record VectorStoreObjectResponse : BaseResponse
     ///     The Unix timestamp (in seconds) for when the vector store was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The name of the vector store.

--- a/OpenAI.SDK/ObjectModels/SharedModels/AssistantFileResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/AssistantFileResponse.cs
@@ -15,7 +15,7 @@ public record AssistantFileResponse : BaseResponse, IOpenAIModels.IId, IOpenAIMo
     ///     The Unix timestamp (in seconds) for when the assistant file was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/AssistantFileResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/AssistantFileResponse.cs
@@ -15,7 +15,9 @@ public record AssistantFileResponse : BaseResponse, IOpenAIModels.IId, IOpenAIMo
     ///     The Unix timestamp (in seconds) for when the assistant file was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/AssistantResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/AssistantResponse.cs
@@ -59,10 +59,28 @@ public record AssistantResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels
     public ResponseFormatOneOfType ResponseFormatOneOfType { get; set; }
 
     /// <summary>
+    ///     What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while
+    ///     lower values like 0.2 will make it more focused and deterministic.
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public float? Temperature { get; set; }
+
+    /// <summary>
+    ///     An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the
+    ///     tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are
+    ///     considered.
+    ///     We generally recommend altering this or temperature but not both.
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public double? TopP { get; set; }
+
+    /// <summary>
     ///     The Unix timestamp (in seconds) for when the assistant was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.
@@ -88,20 +106,4 @@ public record AssistantResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels
     /// </summary>
     [JsonPropertyName("tools")]
     public List<ToolDefinition> Tools { get; set; }
-
-    /// <summary>
-    ///     What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while
-    ///     lower values like 0.2 will make it more focused and deterministic.
-    /// </summary>
-    [JsonPropertyName("temperature")]
-    public float? Temperature { get; set; }
-
-    /// <summary>
-    ///     An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the
-    ///     tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are
-    ///     considered.
-    ///     We generally recommend altering this or temperature but not both.
-    /// </summary>
-    [JsonPropertyName("top_p")]
-    public double? TopP { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/SharedModels/AssistantResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/AssistantResponse.cs
@@ -62,7 +62,7 @@ public record AssistantResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels
     ///     The Unix timestamp (in seconds) for when the assistant was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/EventResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/EventResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Betalgo.Ranul.OpenAI.ObjectModels.SharedModels;
 
-public record EventResponse
+public record EventResponse:IOpenAIModels.ICreatedAt
 {
     [JsonPropertyName("object")]
     public string? ObjectTypeName { get; set; }
@@ -11,7 +11,9 @@ public record EventResponse
     public string? Id { get; set; }
 
     [JsonPropertyName("created_at")]
-    public int? CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
+
 
     [JsonPropertyName("level")]
     public string Level { get; set; }

--- a/OpenAI.SDK/ObjectModels/SharedModels/FileResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FileResponse.cs
@@ -12,8 +12,18 @@ public record FileResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.ICre
     public string FileName { get; set; }
 
     public UploadFilePurposes.UploadFilePurpose PurposeEnum => UploadFilePurposes.ToEnum(Purpose);
-    [JsonPropertyName("purpose")] public string Purpose { get; set; }
-    [JsonPropertyName("status")] public string Status { get; set; }
-    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
-    [JsonPropertyName("id")] public string Id { get; set; }
+
+    [JsonPropertyName("purpose")]
+    public string Purpose { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public long CreatedAtUnix { get; set; }
+
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/SharedModels/FileResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FileResponse.cs
@@ -12,16 +12,8 @@ public record FileResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.ICre
     public string FileName { get; set; }
 
     public UploadFilePurposes.UploadFilePurpose PurposeEnum => UploadFilePurposes.ToEnum(Purpose);
-
-    [JsonPropertyName("purpose")]
-    public string Purpose { get; set; }
-
-    [JsonPropertyName("status")]
-    public string Status { get; set; }
-
-    [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
-
-    [JsonPropertyName("id")]
-    public string Id { get; set; }
+    [JsonPropertyName("purpose")] public string Purpose { get; set; }
+    [JsonPropertyName("status")] public string Status { get; set; }
+    [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
+    [JsonPropertyName("id")] public string Id { get; set; }
 }

--- a/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
@@ -36,7 +36,8 @@ public interface IOpenAIModels
 
     public interface ICreatedAt
     {
-        public long CreatedAt { get; set; }
+        public long CreatedAtUnix { get; set; }
+        public DateTimeOffset CreatedAt { get; }
     }
 
     public interface ICompletedAt

--- a/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/IOpenAiModels.cs
@@ -36,7 +36,7 @@ public interface IOpenAIModels
 
     public interface ICreatedAt
     {
-        public int CreatedAt { get; set; }
+        public long CreatedAt { get; set; }
     }
 
     public interface ICompletedAt

--- a/OpenAI.SDK/ObjectModels/SharedModels/MessageResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/MessageResponse.cs
@@ -14,6 +14,7 @@ public record MessageResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.I
     {
         set => Content = value.Content;
     }
+
     /// <summary>
     ///     The thread ID that this message belongs to.
     /// </summary>
@@ -82,7 +83,11 @@ public record MessageResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.I
     ///     The Unix timestamp (in seconds) for when the message was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+    /// <summary>
+    ///    for when the message was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/MessageResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/MessageResponse.cs
@@ -82,7 +82,7 @@ public record MessageResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.I
     ///     The Unix timestamp (in seconds) for when the message was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/RunResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/RunResponse.cs
@@ -143,7 +143,7 @@ public record RunResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.IMode
     ///     The Unix timestamp (in seconds) for when the run was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The list of File IDs the assistant used for this run.

--- a/OpenAI.SDK/ObjectModels/SharedModels/RunResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/RunResponse.cs
@@ -143,7 +143,12 @@ public record RunResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.IMode
     ///     The Unix timestamp (in seconds) for when the run was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///    for when the run was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The list of File IDs the assistant used for this run.

--- a/OpenAI.SDK/ObjectModels/SharedModels/ThreadResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/ThreadResponse.cs
@@ -18,7 +18,12 @@ public record ThreadResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.IC
     ///     The Unix timestamp (in seconds) for when the assistant was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public long CreatedAt { get; set; }
+    public long CreatedAtUnix { get; set; }
+
+    /// <summary>
+    ///    for when the assistant was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt => DateTimeOffset.FromUnixTimeSeconds(CreatedAtUnix);
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.

--- a/OpenAI.SDK/ObjectModels/SharedModels/ThreadResponse.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/ThreadResponse.cs
@@ -18,7 +18,7 @@ public record ThreadResponse : BaseResponse, IOpenAIModels.IId, IOpenAIModels.IC
     ///     The Unix timestamp (in seconds) for when the assistant was created.
     /// </summary>
     [JsonPropertyName("created_at")]
-    public int CreatedAt { get; set; }
+    public long CreatedAt { get; set; }
 
     /// <summary>
     ///     The identifier, which can be referenced in API endpoints.


### PR DESCRIPTION
This is a copy of PR https://github.com/betalgo/openai/pull/570. I broke that PR while trying to resolve merge conflicts, so it was easier to create a new one and cherry-pick the changes.


AI Summary:
This pull request includes changes to multiple response models in the `OpenAI.SDK` to improve the handling of timestamps by converting Unix timestamps to `DateTimeOffset`. Additionally, new properties for temperature and top_p have been added to the `AssistantResponse` model.

### Timestamp Handling Improvements:
* [`OpenAI.SDK/ObjectModels/ResponseModels/BatchResponseModel/BatchResponse.cs`](diffhunk://#diff-1fe48e61e02dc6d4f9f7e4508ae95b923257eb9a35e255b1ad284bd5ec541a1aL56-R61): Changed `CreatedAt` from `int` to `CreatedAtUnix` of type `long` and added a computed `CreatedAt` property of type `DateTimeOffset`.
* [`OpenAI.SDK/ObjectModels/ResponseModels/ChatCompletionCreateResponse.cs`](diffhunk://#diff-dd4ed26fb3384661208eb96d305e31648680d7926f9ba4c56de9d6db2b8832d3L41-R44): Changed `CreatedAt` from `int` to `CreatedAtUnix` of type `long` and added a computed `CreatedAt` property of type `DateTimeOffset`.
* [`OpenAI.SDK/ObjectModels/ResponseModels/CompletionCreateResponse.cs`](diffhunk://#diff-6b7dd282004b356d2141a9b9b330aa64aa3651013b6f2e3e0d63c3960176aa61L18-R20): Changed `CreatedAt` from `int` to `CreatedAtUnix` of type `long` and added a computed `CreatedAt` property of type `DateTimeOffset`.
* [`OpenAI.SDK/ObjectModels/ResponseModels/EditCreateResponse.cs`](diffhunk://#diff-47c828fb178ad619f3375fbc0931177ac29571a17743c98c907d5505bffdeccbL18-R20): Changed `CreatedAt` from `int` to `CreatedAtUnix` of type `long` and added a computed `CreatedAt` property of type `DateTimeOffset`.
* Similar changes applied to other response models including `FileUploadResponse`, `FineTuneResponse`, `FineTuningJobResponse`, `ImageCreateResponse`, `RunStepResponse`, `VectorStoreFileBatchObject`, `VectorStoreFileObject`, `VectorStoreObjectResponse`, `AssistantFileResponse`, `EventResponse`, `FileResponse`, `MessageResponse`, `RunResponse`, and `ThreadResponse`. [[1]](diffhunk://#diff-65a2453fffebdb3e6aa508340cbcb156e0120084b8bfdd6897abe45cc1873374L21-R23) [[2]](diffhunk://#diff-03cd0d2001d1ee77ec3af7d4c03424533dd068f97faf2318507af4b3ecbda3c6L36-R38) [[3]](diffhunk://#diff-effe9cf12ee8197e9ad9a65a6a17f2c8098d85709fca261b3ec140acae95ce57L70-R75) [[4]](diffhunk://#diff-4b2fc8a8f9d3378fda1ecc2d1a431bb34036298f21d4b11e4246af32728c677bL12-R13) [[5]](diffhunk://#diff-e6c47672dd92b9ab85d0914612fc3b6f25766ec440b6dd763c584deb8646d050L96-R98) [[6]](diffhunk://#diff-0f2735d8986827084c667ee9e8fa6d9cdbd1a269685d71a212e13c529e28e706L18-R22) [[7]](diffhunk://#diff-46e3d8db49008969f35a5f8f3ac60f3b83ecd0d78ade20077ce330a07e56faceL29-R34) [[8]](diffhunk://#diff-e41c3f9306c200514f4ed8281d20c54176f2f3531ea7f91b313e7026964aac57L18-R23) [[9]](diffhunk://#diff-74d04c60d3fb80e16f725ff25a27e6b0f59f33e5593047eff23fec47d3e2795bL18-R20) [[10]](diffhunk://#diff-0a6c4f72f5889de74bf6cce2ed9a7dda9c5ee1bb248ae1d50fbdfee3bdbf8802L5-R5) [[11]](diffhunk://#diff-0a6c4f72f5889de74bf6cce2ed9a7dda9c5ee1bb248ae1d50fbdfee3bdbf8802L14-R16) [[12]](diffhunk://#diff-8dea0826c716c4d3f3253e727d40535c6ab74a0edd48c5003374c3e362354b76L23-R25) [[13]](diffhunk://#diff-25814b6adff6c475c5363f8e34c6761bbc79d1c4ef5009f4144baade785a9f15R17) [[14]](diffhunk://#diff-25814b6adff6c475c5363f8e34c6761bbc79d1c4ef5009f4144baade785a9f15L85-R90) [[15]](diffhunk://#diff-321d1af3cd288370ee5b2066683100321f0b11338ba50d8a50d34c696ce56f86L146-R151) [[16]](diffhunk://#diff-02f74805615e613e874c148da443225030dfefd08675443f58f10045026f2362L21-R26)

### New Properties for AssistantResponse:
* [`OpenAI.SDK/ObjectModels/SharedModels/AssistantResponse.cs`](diffhunk://#diff-9379d32c090a4c09155d2b506e63819fa0652635458b7842cc54ec7cf0d2d76eR61-R83): Added `Temperature` and `TopP` properties to control sampling behavior. [[1]](diffhunk://#diff-9379d32c090a4c09155d2b506e63819fa0652635458b7842cc54ec7cf0d2d76eR61-R83) [[2]](diffhunk://#diff-9379d32c090a4c09155d2b506e63819fa0652635458b7842cc54ec7cf0d2d76eL91-L106)