### PR TITLE
8.10.1

### DIFF
--- a/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
+++ b/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
@@ -10,7 +10,7 @@
 		<PackageIcon>Betalgo-Ranul-OpenAI-icon.png</PackageIcon>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Title>OpenAI SDK by Betalgo</Title>
-		<Version>8.10.0</Version>
+		<Version>8.10.1</Version>
 		<Authors>Tolga Kayhan, Betalgo</Authors>
 		<Company>Betalgo Up Ltd.</Company>
 		<Product>OpenAI .NET library by Betalgo Ranul</Product>

--- a/OpenAI.SDK/Managers/OpenAIEmbeddingGenerator.cs
+++ b/OpenAI.SDK/Managers/OpenAIEmbeddingGenerator.cs
@@ -25,7 +25,7 @@ public partial class OpenAIService : IEmbeddingGenerator<string, Embedding<float
         {
             throw new InvalidOperationException(response.Error is { } error ?
                 $"{response.Error.Code}: {response.Error.Message}" :
-                "Unknown error");
+                "Betalgo.Ranul Unknown error");
         }
 
         return new(response.Data.Select(e => new Embedding<float>(e.Embedding.Select(d => (float)d).ToArray()) { ModelId = response.Model }))

--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,9 @@ Due to time constraints, not all methods have been thoroughly tested or fully do
 Needless to say, I cannot accept responsibility for any damage caused by using the library.
 
 ## Changelog
+### 8.10.1
+- Fixed an issue with the `Store` parameter being included in requests by default, causing errors with Azure OpenAI models. The parameter is now optional and excluded from serialization unless explicitly set.
+
 ### 8.10.0
 - Added support for `Microsoft.Extensions.AI` `IChatClient` and `IEmbeddingGenerator` (more information will be coming soon to the Wiki).
 - Added missing `Temperature` and `TopP` parameters to `AssistantResponse`.

--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ Needless to say, I cannot accept responsibility for any damage caused by using t
 
 ## Changelog
 ### 8.10.0
-- Added support for `Microsoft.Extensions.AI` IChatClient (more information will be coming soon to the Wiki).
+- Added support for `Microsoft.Extensions.AI` `IChatClient` and `IEmbeddingGenerator` (more information will be coming soon to the Wiki).
 - Added missing `Temperature` and `TopP` parameters to `AssistantResponse`.
 - Added missing `Store` parameter to `ChatCompletionCreateRequest`.
 


### PR DESCRIPTION
### 8.10.1
- Fixed an issue with the `Store` parameter being included in requests by default, causing errors with Azure OpenAI models. The parameter is now optional and excluded from serialization unless explicitly set.
