### PR TITLE
Add support for JSON Schema $defs, definitions, $ref, oneOf, anyOf and others in PropertyDefinition

### DIFF
--- a/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
+++ b/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
@@ -9,18 +9,18 @@
 		<PackageProjectUrl>https://openai.com/</PackageProjectUrl>
 		<PackageIcon>Betalgo-Ranul-OpenAI-icon.png</PackageIcon>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Title>Fork fo OpenAI SDK by Betalgo</Title>
-		<Version>9.0.4.7</Version>
+		<Title>OpenAI SDK by Betalgo</Title>
+		<Version>9.0.4</Version>
 		<Authors>Tolga Kayhan, Betalgo</Authors>
 		<Company>Betalgo Up Ltd.</Company>
-		<Product>Fork for OpenAI .NET library by Betalgo Ranul</Product>
+		<Product>OpenAI .NET library by Betalgo Ranul</Product>
 		<Description>.NET library for the OpenAI services by Betalgo Ranul</Description>
 		<RepositoryUrl>https://github.com/betalgo/openai/</RepositoryUrl>
 		<PackageTags>openAI,realtime,chatGPT,gpt-4, gpt-3,DALL·E,whisper,azureOpenAI,ai,betalgo,NLP,dalle,dall-e,OpenAI,OpenAi,openAi,azure</PackageTags>
-		<PackageId>Betalgo.Ranul.OpenAI.Fork</PackageId>
+		<PackageId>Betalgo.Ranul.OpenAI</PackageId>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<RepositoryUrl>https://github.com/repko-artem/betalgo_openai_json_schemas_support.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/betalgo/openai.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
+++ b/OpenAI.SDK/Betalgo.Ranul.OpenAI.csproj
@@ -9,18 +9,18 @@
 		<PackageProjectUrl>https://openai.com/</PackageProjectUrl>
 		<PackageIcon>Betalgo-Ranul-OpenAI-icon.png</PackageIcon>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Title>OpenAI SDK by Betalgo</Title>
-		<Version>9.0.4</Version>
+		<Title>Fork fo OpenAI SDK by Betalgo</Title>
+		<Version>9.0.4.7</Version>
 		<Authors>Tolga Kayhan, Betalgo</Authors>
 		<Company>Betalgo Up Ltd.</Company>
-		<Product>OpenAI .NET library by Betalgo Ranul</Product>
+		<Product>Fork for OpenAI .NET library by Betalgo Ranul</Product>
 		<Description>.NET library for the OpenAI services by Betalgo Ranul</Description>
 		<RepositoryUrl>https://github.com/betalgo/openai/</RepositoryUrl>
 		<PackageTags>openAI,realtime,chatGPT,gpt-4, gpt-3,DALL·E,whisper,azureOpenAI,ai,betalgo,NLP,dalle,dall-e,OpenAI,OpenAi,openAi,azure</PackageTags>
-		<PackageId>Betalgo.Ranul.OpenAI</PackageId>
+		<PackageId>Betalgo.Ranul.OpenAI.Fork</PackageId>
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<RepositoryUrl>https://github.com/betalgo/openai.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/repko-artem/betalgo_openai_json_schemas_support.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/OpenAI.SDK/ObjectModels/Converters.cs
+++ b/OpenAI.SDK/ObjectModels/Converters.cs
@@ -91,9 +91,9 @@ public class AssistantsApiToolChoiceConverter : JsonConverter<AssistantsApiToolC
     }
 }
 
-public class SingleOrArrayToListConverter : JsonConverter<List<string?>>
+public class SingleOrArrayToListConverter : JsonConverter<IList<string?>>
 {
-    public override List<string?>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+    public override IList<string?>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
         switch (reader.TokenType) {
             case JsonTokenType.String:
                 return [reader.GetString()];
@@ -119,7 +119,7 @@ public class SingleOrArrayToListConverter : JsonConverter<List<string?>>
         }
     }
 
-    public override void Write(Utf8JsonWriter writer, List<string?>? value, JsonSerializerOptions options) {
+    public override void Write(Utf8JsonWriter writer, IList<string?>? value, JsonSerializerOptions options) {
         if (value == null || value.Count == 0) {
             writer.WriteNullValue();
         } else if (value.Count == 1) {

--- a/OpenAI.SDK/ObjectModels/Converters.cs
+++ b/OpenAI.SDK/ObjectModels/Converters.cs
@@ -90,3 +90,50 @@ public class AssistantsApiToolChoiceConverter : JsonConverter<AssistantsApiToolC
         }
     }
 }
+
+public class SingleOrArrayToListConverter : JsonConverter<List<string?>>
+{
+    public override List<string?>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
+        switch (reader.TokenType) {
+            case JsonTokenType.String:
+                return [reader.GetString()];
+            case JsonTokenType.StartArray:
+            {
+                var list = new List<string?>();
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray) {
+                    switch (reader.TokenType) {
+                        case JsonTokenType.String:
+                            list.Add(reader.GetString());
+                            break;
+                        case JsonTokenType.Null:
+                            list.Add(null);
+                            break;
+                        default:
+                            throw new JsonException($"Unexpected token in type array: {reader.TokenType}");
+                    }
+                }
+                return list;
+            }
+            default:
+                throw new JsonException($"Unexpected token parsing type: {reader.TokenType}");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<string?>? value, JsonSerializerOptions options) {
+        if (value == null || value.Count == 0) {
+            writer.WriteNullValue();
+        } else if (value.Count == 1) {
+            writer.WriteStringValue(value[0]);
+        } else {
+            writer.WriteStartArray();
+            foreach (var item in value) {
+                if (item == null) {
+                    writer.WriteNullValue();
+                } else {
+                    writer.WriteStringValue(item);
+                }
+            }
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Betalgo.Ranul.OpenAI.ObjectModels.SharedModels;
 
@@ -77,6 +77,33 @@ public class PropertyDefinition
     /// </summary>
     [JsonPropertyName("items")]
     public PropertyDefinition? Items { get; set; }
+    
+    /// <summary>
+    ///     Definitions of schemas (draft-07 specification).
+    ///     For more details, see https://json-schema.org/understanding-json-schema/structuring#defs
+    /// </summary>
+    [JsonPropertyName("$defs")]
+    public IDictionary<string, PropertyDefinition>? Defs { get; set; }
+    
+    /// <summary>
+    ///     Definitions of schemas (draft-07 specification).
+    /// </summary>
+    [JsonPropertyName("definitions")]
+    public IDictionary<string, PropertyDefinition>? Definitions { get; set; }
+    
+    /// <summary>
+    ///     Reference to another schema definition.
+    ///     For more details, see https://json-schema.org/understanding-json-schema/structuring#dollarref
+    /// </summary>
+    [JsonPropertyName("$ref")]
+    public string? Ref { get; set; }
+    
+    /// <summary>
+    ///     To validate against anyOf, the given data must be valid against any (one or more) of the given subschemas.
+    ///     For more details, see https://json-schema.org/understanding-json-schema/reference/combining#anyOf
+    /// </summary>
+    [JsonPropertyName("anyOf")]
+    public IList<PropertyDefinition>? AnyOf { get; set; }
 
     public static PropertyDefinition DefineArray(PropertyDefinition? arrayItems = null)
     {

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -86,6 +86,14 @@ public class PropertyDefinition
     public int? MaxProperties { get; set; }
     
     /// <summary>
+    ///     The value of "multipleOf" MUST be a number, strictly greater than 0.
+    ///     A numeric instance is valid only if division by this keyword's value results in an integer.
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.1
+    /// </summary>
+    [JsonPropertyName("multipleOf")]
+    public int? MultipleOf { get; set; }
+    
+    /// <summary>
     ///     The value of "minimum" MUST be a number, representing an inclusive lower limit for a numeric instance.
     ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-minimum
     /// </summary>
@@ -93,11 +101,57 @@ public class PropertyDefinition
     public float? Minimum { get; set; }
     
     /// <summary>
+    ///     The value of "exclusiveMinimum" MUST be a number, representing an exclusive lower limit for a numeric
+    ///     instance. If the instance is a number, then the instance is valid only if it has a value strictly greater
+    ///     than (not equal to) "exclusiveMinimum".
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.5
+    /// </summary>
+    [JsonPropertyName("exclusiveMinimum")]
+    public float? ExclusiveMinimum { get; set; }
+    
+    /// <summary>
     ///     The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
     ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-maximum
     /// </summary>
     [JsonPropertyName("maximum")]
     public float? Maximum { get; set; }
+    
+    /// <summary>
+    ///     The value of "exclusiveMaximum" MUST be a number, representing an exclusive upper limit for a numeric
+    ///     instance. If the instance is a number, then the instance is valid only if it has a value strictly less than
+    ///     (not equal to) "exclusiveMaximum". 
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.3
+    /// </summary>
+    [JsonPropertyName("exclusiveMaximum")]
+    public float? ExclusiveMaximum { get; set; }
+    
+    /// <summary>
+    ///     Predefined formats for strings. Currently supported:
+    ///     date-time, time, date, duration, email, hostname, ipv4, ipv6, uuid
+    /// </summary>
+    [JsonPropertyName("format")]
+    public string? Format { get; set; }
+    
+    /// <summary>
+    ///     A regular expression that the string must match.
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#pattern
+    /// </summary>
+    [JsonPropertyName("pattern")]
+    public string? Pattern { get; set; }
+    
+    /// <summary>
+    ///     The array must have at least this many items.
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.4.2
+    /// </summary>
+    [JsonPropertyName("minItems")]
+    public int? MinItems { get; set; }
+    
+    /// <summary>
+    ///     The array must have at most this many items.
+    ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.4.4
+    /// </summary>
+    [JsonPropertyName("maxItems")]
+    public int? MaxItems { get; set; }
 
     /// <summary>
     ///     If type is "array", this specifies the element type for all items in the array.

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -79,7 +79,7 @@ public class PropertyDefinition
     public PropertyDefinition? Items { get; set; }
     
     /// <summary>
-    ///     Definitions of schemas (draft-07 specification).
+    ///     Definitions of schemas (2020-12 and newer specifications).
     ///     For more details, see https://json-schema.org/understanding-json-schema/structuring#defs
     /// </summary>
     [JsonPropertyName("$defs")]

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -20,10 +20,26 @@ public class PropertyDefinition
     }
 
     /// <summary>
-    ///     Function parameter object type. Default value is "object".
+    ///     Property's type as a string. Only one: <see cref="TypeList"/> or <see cref="Type"/> should be set.
+    /// </summary>
+    [JsonIgnore]
+    public string? Type {
+        get => TypeList?.Count != 1 ? null : TypeList[0];
+        set {
+            if (value == null) {
+                TypeList = null;
+                return;
+            }
+            TypeList = [value];
+        }
+    }
+
+    /// <summary>
+    ///     Property's type as a list of strings. Only one: <see cref="TypeList"/> or <see cref="Type"/> should be set.
     /// </summary>
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
+    [JsonConverter(typeof(SingleOrArrayToListConverter))]
+    public IList<string?>? TypeList { get; set; }
     
     /// <summary>
     ///     An instance validates successfully against this keyword if its value is equal to the value of the keyword

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -23,7 +23,14 @@ public class PropertyDefinition
     ///     Required. Function parameter object type. Default value is "object".
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; } = "object";
+    public string? Type { get; set; }
+    
+    /// <summary>
+    ///     An instance validates successfully against this keyword if its value is equal to the value of the keyword
+    ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-const
+    /// </summary>
+    [JsonPropertyName("const")]
+    public string? Constant { get; set; }
 
     /// <summary>
     ///     Optional. List of "function arguments", as a dictionary that maps from argument name
@@ -45,7 +52,15 @@ public class PropertyDefinition
     public bool? AdditionalProperties { get; set; }
 
     /// <summary>
-    ///     Optional. Argument description.
+    ///     Optional. Title of the schema.
+    ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-title-and-description
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    /// <summary>
+    ///     Optional. Description of the schema.
+    ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-title-and-description
     /// </summary>
     [JsonPropertyName("description")]
     public string? Description { get; set; }
@@ -69,6 +84,20 @@ public class PropertyDefinition
     /// </summary>
     [JsonPropertyName("maxProperties")]
     public int? MaxProperties { get; set; }
+    
+    /// <summary>
+    ///     The value of "minimum" MUST be a number, representing an inclusive lower limit for a numeric instance.
+    ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-minimum
+    /// </summary>
+    [JsonPropertyName("minimum")]
+    public float? Minimum { get; set; }
+    
+    /// <summary>
+    ///     The value of "maximum" MUST be a number, representing an inclusive upper limit for a numeric instance.
+    ///     https://json-schema.org/draft/2020-12/json-schema-validation#name-maximum
+    /// </summary>
+    [JsonPropertyName("maximum")]
+    public float? Maximum { get; set; }
 
     /// <summary>
     ///     If type is "array", this specifies the element type for all items in the array.
@@ -104,6 +133,13 @@ public class PropertyDefinition
     /// </summary>
     [JsonPropertyName("anyOf")]
     public IList<PropertyDefinition>? AnyOf { get; set; }
+    
+    /// <summary>
+    ///     To validate against oneOf, the given data must be valid against exactly one of the given subschemas.
+    ///     For more details, see https://json-schema.org/understanding-json-schema/reference/combining#oneOf
+    /// </summary>
+    [JsonPropertyName("oneOf")]
+    public IList<PropertyDefinition>? OneOf { get; set; }
 
     public static PropertyDefinition DefineArray(PropertyDefinition? arrayItems = null)
     {

--- a/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
+++ b/OpenAI.SDK/ObjectModels/SharedModels/FunctionParameters.cs
@@ -20,7 +20,7 @@ public class PropertyDefinition
     }
 
     /// <summary>
-    ///     Required. Function parameter object type. Default value is "object".
+    ///     Function parameter object type. Default value is "object".
     /// </summary>
     [JsonPropertyName("type")]
     public string? Type { get; set; }
@@ -91,7 +91,7 @@ public class PropertyDefinition
     ///     https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.1
     /// </summary>
     [JsonPropertyName("multipleOf")]
-    public int? MultipleOf { get; set; }
+    public float? MultipleOf { get; set; }
     
     /// <summary>
     ///     The value of "minimum" MUST be a number, representing an inclusive lower limit for a numeric instance.


### PR DESCRIPTION
This PR extends PropertyDefinition to support additional JSON Schema draft-07 elements:

- **$defs** (for schema definitions)
- **definitions** (old draft-07 keyword)
- **$ref** (schema references)
- **anyOf** (combining subschemas)
- **oneOf** (choosing a schema)
- **const** (constant value)
- **min** and **max** (range for possible values)
- **title** (the same as description, but shorter)
- some others related to https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat&type-restrictions=number-restrictions#supported-properties

Also support array-like type of property to support optional props https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required like
```
"type": ["string", "null"]
```

These additions improve compatibility with more complex JSON Schema structures.