### PR TITLE
Update NuGet key for OpenAI utilities publishing

### DIFF
--- a/.github/workflows/BuildAndDeployBetalgoOpenAIUtilities.yml
+++ b/.github/workflows/BuildAndDeployBetalgoOpenAIUtilities.yml
@@ -32,6 +32,6 @@ jobs:
       uses: alirezanet/publish-nuget@v3.1.0
       with:
           PROJECT_FILE_PATH: OpenAI.Utilities\Betalgo.OpenAI.Utilities.csproj
-          NUGET_KEY: ${{secrets.NUGET_KEY}}
+          NUGET_KEY: ${{secrets.NUGET_KEY_UTILITIES}}
           INCLUDE_SYMBOLS: true
           PACKAGE_NAME: Betalgo.OpenAI.Utilities


### PR DESCRIPTION
Changed the `NUGET_KEY` in `BuildAndDeployBetalgoOpenAIUtilities.yml` to use `${{secrets.NUGET_KEY_UTILITIES}}` for publishing the NuGet package.